### PR TITLE
feat: connect PDF uploads to quizzes with publish control

### DIFF
--- a/.infra/bootstrap/variables.tf
+++ b/.infra/bootstrap/variables.tf
@@ -17,7 +17,7 @@ variable "project_name" {
 variable "github_org" {
   description = "GitHub organization or username"
   type        = string
-  default     = "Redm0nd"  # Update this to your GitHub org/username
+  default     = "Redm0nd" # Update this to your GitHub org/username
 
   nullable = false
 }

--- a/.infra/modules/database/main.tf
+++ b/.infra/modules/database/main.tf
@@ -40,6 +40,11 @@ resource "aws_dynamodb_table" "this" {
     type = "S"
   }
 
+  attribute {
+    name = "jobId"
+    type = "S"
+  }
+
   # Global Secondary Index for querying all quizzes
   global_secondary_index {
     name            = "Type-createdAt-index"
@@ -69,6 +74,14 @@ resource "aws_dynamodb_table" "this" {
     name            = "Hash-index"
     hash_key        = "hash"
     projection_type = "KEYS_ONLY"
+  }
+
+  # GSI for querying questions by jobId and status (for quiz questions)
+  global_secondary_index {
+    name            = "JobId-Status-index"
+    hash_key        = "jobId"
+    range_key       = "status"
+    projection_type = "ALL"
   }
 
   # Enable point-in-time recovery for data protection

--- a/backend/build.js
+++ b/backend/build.js
@@ -21,6 +21,7 @@ const handlers = [
   'reviewQuestion',
   'bulkReviewQuestions',
   'getExtractionJobs',
+  'publishQuiz',
 ];
 
 async function buildHandler(handlerName) {

--- a/backend/src/handlers/getQuiz.ts
+++ b/backend/src/handlers/getQuiz.ts
@@ -1,10 +1,21 @@
 import type { APIGatewayProxyEvent, APIGatewayProxyResult, QuizDetail } from '../lib/types.js';
-import { getQuizById } from '../lib/dynamodb.js';
+import { getExtractionJob } from '../lib/dynamodb.js';
 import { successResponse, errorResponse } from '../lib/response.js';
 
 /**
+ * Format filename into a readable quiz title
+ * e.g., "laws-of-the-game-2024.pdf" -> "Laws Of The Game 2024"
+ */
+function formatTitle(fileName: string): string {
+  return fileName
+    .replace(/\.pdf$/i, '') // Remove .pdf extension
+    .replace(/[-_]/g, ' ') // Replace dashes and underscores with spaces
+    .replace(/\b\w/g, (char) => char.toUpperCase()); // Title case
+}
+
+/**
  * GET /quizzes/{id}
- * Returns quiz metadata
+ * Returns quiz metadata (from extraction job)
  */
 export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
   console.log('Event:', JSON.stringify(event, null, 2));
@@ -16,21 +27,26 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
   }
 
   try {
-    const quiz = await getQuizById(quizId);
+    const job = await getExtractionJob(quizId);
 
-    if (!quiz) {
+    if (!job) {
       return errorResponse('Quiz not found', 404);
     }
 
-    // Transform to detail format
+    // Only return published jobs with approved questions
+    if (!job.published || job.approvedCount === 0) {
+      return errorResponse('Quiz not found', 404);
+    }
+
+    // Transform job to quiz detail format
     const detail: QuizDetail = {
-      quizId: quiz.quizId,
-      title: quiz.title,
-      description: quiz.description,
-      category: quiz.category,
-      questionCount: quiz.questionCount,
-      createdAt: quiz.createdAt,
-      updatedAt: quiz.updatedAt,
+      quizId: job.jobId,
+      title: formatTitle(job.fileName),
+      description: `Questions extracted from ${job.fileName}`,
+      category: 'Laws of the Game',
+      questionCount: job.approvedCount,
+      createdAt: job.createdAt,
+      updatedAt: job.updatedAt,
     };
 
     return successResponse(detail);

--- a/backend/src/handlers/publishQuiz.ts
+++ b/backend/src/handlers/publishQuiz.ts
@@ -1,0 +1,68 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from '../lib/types.js';
+import { getExtractionJob, publishJob, unpublishJob } from '../lib/dynamodb.js';
+import { successResponse, errorResponse } from '../lib/response.js';
+
+interface PublishRequest {
+  publish: boolean;
+}
+
+/**
+ * PUT /admin/jobs/{id}/publish
+ * Publish or unpublish a job (make it visible/hidden on the homepage)
+ */
+export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  console.log('Event:', JSON.stringify(event, null, 2));
+
+  const jobId = event.pathParameters?.id;
+
+  if (!jobId) {
+    return errorResponse('Missing job ID', 400);
+  }
+
+  // Default to publish: true if no body provided
+  let request: PublishRequest = { publish: true };
+
+  if (event.body) {
+    try {
+      request = JSON.parse(event.body);
+    } catch {
+      return errorResponse('Invalid JSON body', 400);
+    }
+  }
+
+  const shouldPublish = request.publish !== false;
+
+  try {
+    const job = await getExtractionJob(jobId);
+
+    if (!job) {
+      return errorResponse('Job not found', 404);
+    }
+
+    // Only allow publishing completed jobs with approved questions
+    if (shouldPublish && job.status !== 'completed') {
+      return errorResponse('Only completed jobs can be published', 400);
+    }
+
+    if (shouldPublish && job.approvedCount === 0) {
+      return errorResponse('Cannot publish a job with no approved questions', 400);
+    }
+
+    if (shouldPublish) {
+      await publishJob(jobId);
+    } else {
+      await unpublishJob(jobId);
+    }
+
+    return successResponse({
+      jobId,
+      published: shouldPublish,
+      message: shouldPublish
+        ? 'Quiz published successfully'
+        : 'Quiz unpublished successfully',
+    });
+  } catch (error) {
+    console.error('Error publishing job:', error);
+    return errorResponse('Failed to update publish status', 500);
+  }
+}

--- a/backend/src/lib/types.ts
+++ b/backend/src/lib/types.ts
@@ -71,6 +71,7 @@ export interface ExtractionJobItem {
   pendingCount: number;
   rejectedCount: number;
   duplicateCount: number;
+  published?: boolean;
   errorMessage?: string;
   createdAt: string;
   updatedAt: string;
@@ -130,6 +131,7 @@ export interface ExtractionJob {
   pendingCount: number;
   rejectedCount: number;
   duplicateCount: number;
+  published?: boolean;
   errorMessage?: string;
   createdAt: string;
   completedAt?: string;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -8,6 +8,7 @@ import type {
   JobDetailResponse,
   ReviewResponse,
   BulkReviewResponse,
+  PublishResponse,
   QuestionStatus,
   Law,
 } from '../types';
@@ -129,5 +130,15 @@ export async function bulkReviewQuestions(
   return fetchAPI<BulkReviewResponse>('/admin/questions/bulk-review', {
     method: 'POST',
     body: JSON.stringify({ questionIds, status, reviewedBy }),
+  });
+}
+
+export async function publishQuiz(
+  jobId: string,
+  publish = true
+): Promise<PublishResponse> {
+  return fetchAPI<PublishResponse>(`/admin/jobs/${jobId}/publish`, {
+    method: 'PUT',
+    body: JSON.stringify({ publish }),
   });
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -68,6 +68,7 @@ export interface ExtractionJob {
   pendingCount: number;
   rejectedCount: number;
   duplicateCount: number;
+  published?: boolean;
   errorMessage?: string;
   createdAt: string;
   completedAt?: string;
@@ -119,4 +120,10 @@ export interface BulkReviewResponse {
     failed: number;
     targetStatus: QuestionStatus;
   };
+}
+
+export interface PublishResponse {
+  jobId: string;
+  published: boolean;
+  message: string;
 }


### PR DESCRIPTION
## Summary

- Extraction jobs now serve as quizzes on the homepage
- Adds publish control so admins can choose when quizzes become visible
- Uses new GSI for efficient querying of approved questions by jobId

## Changes

### Infrastructure
- Added `JobId-Status-index` GSI to DynamoDB for efficient question queries
- Added `publishQuiz` Lambda function with API Gateway route `PUT /admin/jobs/{id}/publish`

### Backend
- Added `published` field to ExtractionJob types
- Added DynamoDB functions: `getApprovedQuestionsByJobId()`, `getPublishedJobs()`, `publishJob()`, `unpublishJob()`
- Modified `getQuizzes` to query published jobs instead of separate Quiz items
- Modified `getQuiz` to return job metadata as QuizDetail
- Modified `getQuestions` to query approved bank questions by jobId
- Created `publishQuiz` handler for publishing/unpublishing jobs

### Frontend
- Added `publishQuiz()` function to API client
- Added Publish/Unpublish button to JobDetail page
- Shows "Published" badge for published quizzes

## Flow
1. Admin uploads PDF → questions extracted → job completed
2. Admin reviews/approves questions in admin portal
3. Admin clicks "Publish Quiz" when ready → sets `published: true`
4. Homepage shows only published jobs with approved questions
5. User takes quiz → fetches approved questions for that jobId

## Test plan
- [ ] Upload a PDF through `/admin/upload`
- [ ] Wait for extraction to complete (check `/admin/jobs`)
- [ ] Approve some questions in the job detail page
- [ ] Click "Publish Quiz" button
- [ ] Visit homepage - should see the quiz
- [ ] Take the quiz - should get the approved questions
- [ ] Unpublish the quiz - should no longer appear on homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)