### PR TITLE
fix(ci): build backend before terraform to prevent missing zip errors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,11 +42,45 @@ jobs:
             frontend:
               - 'frontend/**'
 
+  # Build backend early - Terraform needs zip files to exist for Lambda resources
+  build-backend:
+    name: Build Backend
+    runs-on: ubuntu-latest
+    needs: changes
+    # Build if infra or backend changed (infra needs zips for Lambda resources)
+    if: needs.changes.outputs.infra == 'true' || needs.changes.outputs.backend == 'true'
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build Lambda Functions
+        run: npm run build
+
+      - name: Upload Lambda Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: lambda-zips
+          path: backend/dist/*.zip
+          retention-days: 1
+
   # Terraform Plan - only runs if infra changed
   terraform-plan:
     name: Terraform Plan
     runs-on: ubuntu-latest
-    needs: changes
+    needs: [changes, build-backend]
     if: needs.changes.outputs.infra == 'true'
     defaults:
       run:
@@ -56,6 +90,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Download Lambda Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: lambda-zips
+          path: backend/dist
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -125,7 +165,7 @@ jobs:
   terraform-apply:
     name: Terraform Apply
     runs-on: ubuntu-latest
-    needs: [changes, terraform-plan]
+    needs: [changes, build-backend, terraform-plan]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.changes.outputs.infra == 'true'
     environment: production
     defaults:
@@ -134,6 +174,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Download Lambda Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: lambda-zips
+          path: backend/dist
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -187,6 +233,7 @@ jobs:
       lambda_review_question: ${{ steps.tf-output.outputs.lambda_review_question }}
       lambda_bulk_review_questions: ${{ steps.tf-output.outputs.lambda_bulk_review_questions }}
       lambda_get_extraction_jobs: ${{ steps.tf-output.outputs.lambda_get_extraction_jobs }}
+      lambda_publish_quiz: ${{ steps.tf-output.outputs.lambda_publish_quiz }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -221,37 +268,25 @@ jobs:
           echo "lambda_review_question=$(terraform output -json lambda_function_names | jq -r '.review_question')" >> $GITHUB_OUTPUT
           echo "lambda_bulk_review_questions=$(terraform output -json lambda_function_names | jq -r '.bulk_review_questions')" >> $GITHUB_OUTPUT
           echo "lambda_get_extraction_jobs=$(terraform output -json lambda_function_names | jq -r '.get_extraction_jobs')" >> $GITHUB_OUTPUT
+          echo "lambda_publish_quiz=$(terraform output -json lambda_function_names | jq -r '.publish_quiz')" >> $GITHUB_OUTPUT
 
-  # Build and Deploy Backend
+  # Deploy Backend - uses pre-built artifacts
   deploy-backend:
     name: Deploy Backend
     runs-on: ubuntu-latest
-    needs: [changes, get-outputs]
+    needs: [changes, build-backend, get-outputs]
     if: |
       always() &&
       github.ref == 'refs/heads/main' &&
       github.event_name == 'push' &&
       needs.changes.outputs.backend == 'true' &&
       needs.get-outputs.result == 'success'
-    defaults:
-      run:
-        working-directory: backend
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Download Lambda Artifacts
+        uses: actions/download-artifact@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-          cache-dependency-path: backend/package-lock.json
-
-      - name: Install Dependencies
-        run: npm ci
-
-      - name: Build Lambda Functions
-        run: npm run build
+          name: lambda-zips
+          path: backend/dist
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -263,55 +298,61 @@ jobs:
         run: |
           aws lambda update-function-code \
             --function-name ${{ needs.get-outputs.outputs.lambda_get_quizzes }} \
-            --zip-file fileb://dist/getQuizzes.zip
+            --zip-file fileb://backend/dist/getQuizzes.zip
 
       - name: Update Lambda - getQuiz
         run: |
           aws lambda update-function-code \
             --function-name ${{ needs.get-outputs.outputs.lambda_get_quiz }} \
-            --zip-file fileb://dist/getQuiz.zip
+            --zip-file fileb://backend/dist/getQuiz.zip
 
       - name: Update Lambda - getQuestions
         run: |
           aws lambda update-function-code \
             --function-name ${{ needs.get-outputs.outputs.lambda_get_questions }} \
-            --zip-file fileb://dist/getQuestions.zip
+            --zip-file fileb://backend/dist/getQuestions.zip
 
       - name: Update Lambda - generatePresignedUrl
         run: |
           aws lambda update-function-code \
             --function-name ${{ needs.get-outputs.outputs.lambda_generate_presigned_url }} \
-            --zip-file fileb://dist/generatePresignedUrl.zip
+            --zip-file fileb://backend/dist/generatePresignedUrl.zip
 
       - name: Update Lambda - processPdf
         run: |
           aws lambda update-function-code \
             --function-name ${{ needs.get-outputs.outputs.lambda_process_pdf }} \
-            --zip-file fileb://dist/processPdf.zip
+            --zip-file fileb://backend/dist/processPdf.zip
 
       - name: Update Lambda - getQuestionBank
         run: |
           aws lambda update-function-code \
             --function-name ${{ needs.get-outputs.outputs.lambda_get_question_bank }} \
-            --zip-file fileb://dist/getQuestionBank.zip
+            --zip-file fileb://backend/dist/getQuestionBank.zip
 
       - name: Update Lambda - reviewQuestion
         run: |
           aws lambda update-function-code \
             --function-name ${{ needs.get-outputs.outputs.lambda_review_question }} \
-            --zip-file fileb://dist/reviewQuestion.zip
+            --zip-file fileb://backend/dist/reviewQuestion.zip
 
       - name: Update Lambda - bulkReviewQuestions
         run: |
           aws lambda update-function-code \
             --function-name ${{ needs.get-outputs.outputs.lambda_bulk_review_questions }} \
-            --zip-file fileb://dist/bulkReviewQuestions.zip
+            --zip-file fileb://backend/dist/bulkReviewQuestions.zip
 
       - name: Update Lambda - getExtractionJobs
         run: |
           aws lambda update-function-code \
             --function-name ${{ needs.get-outputs.outputs.lambda_get_extraction_jobs }} \
-            --zip-file fileb://dist/getExtractionJobs.zip
+            --zip-file fileb://backend/dist/getExtractionJobs.zip
+
+      - name: Update Lambda - publishQuiz
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ needs.get-outputs.outputs.lambda_publish_quiz }} \
+            --zip-file fileb://backend/dist/publishQuiz.zip
 
   # Build and Deploy Frontend
   deploy-frontend:


### PR DESCRIPTION
## Summary

- Fixes race condition where Terraform fails when adding new Lambda functions because zip files don't exist yet
- Adds `build-backend` job that runs early when infra or backend changes
- `terraform-plan` and `terraform-apply` now download pre-built Lambda artifacts
- `deploy-backend` reuses artifacts instead of rebuilding
- Adds missing `lambda_publish_quiz` to terraform outputs

## Problem

When adding a new Lambda function (like `publishQuiz`), Terraform needs the zip file to exist to create the `aws_lambda_function` resource. Previously:

1. `terraform-apply` ran first - failed because `publishQuiz.zip` did not exist
2. `deploy-backend` ran after - would have created the zip, but never got the chance

## Solution

New workflow order:
1. `changes` - detect what changed
2. `build-backend` - build Lambda zips early (if infra OR backend changed)
3. `terraform-plan/apply` - download artifacts, then run Terraform
4. `deploy-backend` - download artifacts, update Lambda code

This ensures zip files always exist before Terraform runs.

## Test plan

- [ ] Merge this PR
- [ ] Make a change to `.infra/` that does not add new Lambdas - should work as before
- [ ] Future: when adding a new Lambda, the build will run first and Terraform will have the zip

Generated with [Claude Code](https://claude.ai/claude-code)
