### PR TITLE
feat: add manual quiz creation and enhanced metadata tracking

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -234,6 +234,8 @@ jobs:
       lambda_bulk_review_questions: ${{ steps.tf-output.outputs.lambda_bulk_review_questions }}
       lambda_get_extraction_jobs: ${{ steps.tf-output.outputs.lambda_get_extraction_jobs }}
       lambda_publish_quiz: ${{ steps.tf-output.outputs.lambda_publish_quiz }}
+      lambda_create_manual_job: ${{ steps.tf-output.outputs.lambda_create_manual_job }}
+      lambda_add_manual_question: ${{ steps.tf-output.outputs.lambda_add_manual_question }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -269,6 +271,8 @@ jobs:
           echo "lambda_bulk_review_questions=$(terraform output -json lambda_function_names | jq -r '.bulk_review_questions')" >> $GITHUB_OUTPUT
           echo "lambda_get_extraction_jobs=$(terraform output -json lambda_function_names | jq -r '.get_extraction_jobs')" >> $GITHUB_OUTPUT
           echo "lambda_publish_quiz=$(terraform output -json lambda_function_names | jq -r '.publish_quiz')" >> $GITHUB_OUTPUT
+          echo "lambda_create_manual_job=$(terraform output -json lambda_function_names | jq -r '.create_manual_job')" >> $GITHUB_OUTPUT
+          echo "lambda_add_manual_question=$(terraform output -json lambda_function_names | jq -r '.add_manual_question')" >> $GITHUB_OUTPUT
 
   # Deploy Backend - uses pre-built artifacts
   deploy-backend:
@@ -353,6 +357,18 @@ jobs:
           aws lambda update-function-code \
             --function-name ${{ needs.get-outputs.outputs.lambda_publish_quiz }} \
             --zip-file fileb://backend/dist/publishQuiz.zip
+
+      - name: Update Lambda - createManualJob
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ needs.get-outputs.outputs.lambda_create_manual_job }} \
+            --zip-file fileb://backend/dist/createManualJob.zip
+
+      - name: Update Lambda - addManualQuestion
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ needs.get-outputs.outputs.lambda_add_manual_question }} \
+            --zip-file fileb://backend/dist/addManualQuestion.zip
 
   # Build and Deploy Frontend
   deploy-frontend:

--- a/.infra/modules/backend/outputs.tf
+++ b/.infra/modules/backend/outputs.tf
@@ -25,6 +25,8 @@ output "lambda_function_names" {
     review_question        = aws_lambda_function.review_question.function_name
     bulk_review_questions  = aws_lambda_function.bulk_review_questions.function_name
     get_extraction_jobs    = aws_lambda_function.get_extraction_jobs.function_name
+    create_manual_job      = aws_lambda_function.create_manual_job.function_name
+    add_manual_question    = aws_lambda_function.add_manual_question.function_name
   }
 }
 
@@ -40,6 +42,8 @@ output "lambda_function_arns" {
     review_question        = aws_lambda_function.review_question.arn
     bulk_review_questions  = aws_lambda_function.bulk_review_questions.arn
     get_extraction_jobs    = aws_lambda_function.get_extraction_jobs.arn
+    create_manual_job      = aws_lambda_function.create_manual_job.arn
+    add_manual_question    = aws_lambda_function.add_manual_question.arn
   }
 }
 

--- a/backend/build.js
+++ b/backend/build.js
@@ -22,6 +22,9 @@ const handlers = [
   'bulkReviewQuestions',
   'getExtractionJobs',
   'publishQuiz',
+  // Manual quiz creation handlers
+  'createManualJob',
+  'addManualQuestion',
 ];
 
 async function buildHandler(handlerName) {

--- a/backend/src/handlers/addManualQuestion.ts
+++ b/backend/src/handlers/addManualQuestion.ts
@@ -1,0 +1,168 @@
+import { createHash } from 'crypto';
+import { ulid } from 'ulid';
+import type {
+  APIGatewayProxyEvent,
+  APIGatewayProxyResult,
+  BankQuestionItem,
+  Law,
+  Difficulty,
+} from '../lib/types.js';
+import {
+  getExtractionJob,
+  updateExtractionJob,
+  saveBankQuestion,
+  questionExistsByHash,
+} from '../lib/dynamodb.js';
+import { successResponse, errorResponse } from '../lib/response.js';
+
+interface AddManualQuestionRequest {
+  text: string;
+  options: string[];
+  correctAnswer: number;
+  explanation: string;
+  law: Law;
+  lawReference: string;
+  difficulty?: Difficulty;
+  tags?: string[];
+}
+
+const VALID_LAWS: Law[] = [
+  'Law 1', 'Law 2', 'Law 3', 'Law 4', 'Law 5',
+  'Law 6', 'Law 7', 'Law 8', 'Law 9', 'Law 10',
+  'Law 11', 'Law 12', 'Law 13', 'Law 14', 'Law 15',
+  'Law 16', 'Law 17',
+];
+
+const VALID_DIFFICULTIES: Difficulty[] = ['easy', 'medium', 'hard'];
+
+/**
+ * Generate content hash for deduplication
+ */
+function generateQuestionHash(text: string, options: string[]): string {
+  const content = `${text}|${options.join('|')}`.toLowerCase().trim();
+  return createHash('sha256').update(content).digest('hex').substring(0, 32);
+}
+
+/**
+ * POST /admin/jobs/{id}/questions
+ * Adds a question to a manual job
+ */
+export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  console.log('Event:', JSON.stringify(event, null, 2));
+
+  const jobId = event.pathParameters?.id;
+
+  if (!jobId) {
+    return errorResponse('Job ID is required', 400);
+  }
+
+  if (!event.body) {
+    return errorResponse('Request body is required', 400);
+  }
+
+  let request: AddManualQuestionRequest;
+  try {
+    request = JSON.parse(event.body);
+  } catch {
+    return errorResponse('Invalid JSON body', 400);
+  }
+
+  // Validate request
+  if (!request.text || request.text.trim() === '') {
+    return errorResponse('text is required', 400);
+  }
+
+  if (!Array.isArray(request.options) || request.options.length !== 4) {
+    return errorResponse('options must be an array of exactly 4 strings', 400);
+  }
+
+  if (request.options.some((opt) => typeof opt !== 'string' || opt.trim() === '')) {
+    return errorResponse('All options must be non-empty strings', 400);
+  }
+
+  if (typeof request.correctAnswer !== 'number' || request.correctAnswer < 0 || request.correctAnswer > 3) {
+    return errorResponse('correctAnswer must be a number between 0 and 3', 400);
+  }
+
+  if (!request.explanation || request.explanation.trim() === '') {
+    return errorResponse('explanation is required', 400);
+  }
+
+  if (!request.law || !VALID_LAWS.includes(request.law)) {
+    return errorResponse('law must be a valid law (Law 1 through Law 17)', 400);
+  }
+
+  if (!request.lawReference || request.lawReference.trim() === '') {
+    return errorResponse('lawReference is required', 400);
+  }
+
+  if (request.difficulty && !VALID_DIFFICULTIES.includes(request.difficulty)) {
+    return errorResponse('difficulty must be easy, medium, or hard', 400);
+  }
+
+  if (request.tags && !Array.isArray(request.tags)) {
+    return errorResponse('tags must be an array of strings', 400);
+  }
+
+  try {
+    // Verify job exists
+    const job = await getExtractionJob(jobId);
+
+    if (!job) {
+      return errorResponse('Job not found', 404);
+    }
+
+    // Check for duplicate question
+    const hash = generateQuestionHash(request.text, request.options);
+    const isDuplicate = await questionExistsByHash(hash);
+
+    if (isDuplicate) {
+      return errorResponse('A similar question already exists', 409);
+    }
+
+    const questionId = ulid();
+    const now = new Date().toISOString();
+
+    const question: BankQuestionItem = {
+      PK: `QUESTION#${questionId}`,
+      SK: 'METADATA',
+      Type: 'BankQuestion',
+      questionId,
+      text: request.text.trim(),
+      options: request.options.map((opt) => opt.trim()),
+      correctAnswer: request.correctAnswer,
+      explanation: request.explanation.trim(),
+      law: request.law,
+      lawReference: request.lawReference.trim(),
+      confidence: 1.0, // Manual entry has 100% confidence
+      status: 'approved', // Manual questions are auto-approved
+      sourceFile: '', // No source file for manual entry
+      jobId,
+      hash,
+      createdAt: now,
+      updatedAt: now,
+      // New fields for manual entry
+      source: 'manual_entry',
+      difficulty: request.difficulty,
+      tags: request.tags?.map((tag) => tag.trim()).filter((tag) => tag !== ''),
+      usageCount: 0,
+    };
+
+    await saveBankQuestion(question);
+
+    // Update job counts
+    await updateExtractionJob(jobId, {
+      totalQuestions: job.totalQuestions + 1,
+      approvedCount: job.approvedCount + 1,
+      updatedAt: now,
+    });
+
+    return successResponse({
+      questionId,
+      message: 'Question added successfully',
+    }, 201);
+  } catch (error) {
+    console.error('Error adding question:', error);
+    return errorResponse('Failed to add question', 500);
+  }
+}

--- a/backend/src/handlers/createManualJob.ts
+++ b/backend/src/handlers/createManualJob.ts
@@ -1,0 +1,70 @@
+import { ulid } from 'ulid';
+import type { APIGatewayProxyEvent, APIGatewayProxyResult, ExtractionJobItem } from '../lib/types.js';
+import { createExtractionJob } from '../lib/dynamodb.js';
+import { successResponse, errorResponse } from '../lib/response.js';
+
+interface CreateManualJobRequest {
+  title: string;
+  description?: string;
+  category?: string;
+}
+
+/**
+ * POST /admin/jobs/manual
+ * Creates a new "manual" job that can have questions added to it
+ */
+export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  console.log('Event:', JSON.stringify(event, null, 2));
+
+  if (!event.body) {
+    return errorResponse('Request body is required', 400);
+  }
+
+  let request: CreateManualJobRequest;
+  try {
+    request = JSON.parse(event.body);
+  } catch {
+    return errorResponse('Invalid JSON body', 400);
+  }
+
+  if (!request.title || request.title.trim() === '') {
+    return errorResponse('title is required', 400);
+  }
+
+  try {
+    const jobId = ulid();
+    const now = new Date().toISOString();
+
+    const job: ExtractionJobItem = {
+      PK: `JOB#${jobId}`,
+      SK: 'METADATA',
+      Type: 'ExtractionJob',
+      jobId,
+      s3Key: '', // No S3 key for manual jobs
+      fileName: request.title.trim(),
+      status: 'completed', // Manual jobs start as completed
+      totalQuestions: 0,
+      approvedCount: 0,
+      pendingCount: 0,
+      rejectedCount: 0,
+      duplicateCount: 0,
+      createdAt: now,
+      updatedAt: now,
+      completedAt: now,
+      // New fields for manual entry
+      source: 'manual_entry',
+      description: request.description?.trim() || '',
+      category: request.category?.trim() || 'Laws of the Game',
+    };
+
+    await createExtractionJob(job);
+
+    return successResponse({
+      jobId,
+      message: 'Manual job created successfully',
+    }, 201);
+  } catch (error) {
+    console.error('Error creating manual job:', error);
+    return errorResponse('Failed to create manual job', 500);
+  }
+}

--- a/backend/src/handlers/getQuestions.ts
+++ b/backend/src/handlers/getQuestions.ts
@@ -1,5 +1,5 @@
 import type { APIGatewayProxyEvent, APIGatewayProxyResult, Question } from '../lib/types.js';
-import { getApprovedQuestionsByJobId, getExtractionJob, shuffleArray } from '../lib/dynamodb.js';
+import { getApprovedQuestionsByJobId, getExtractionJob, shuffleArray, updateQuestionUsage } from '../lib/dynamodb.js';
 import { successResponse, errorResponse } from '../lib/response.js';
 
 /**
@@ -45,6 +45,12 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
       text: q.text,
       options: q.options,
     }));
+
+    // Track usage for the selected questions (fire and forget)
+    const questionIds = shuffled.map((q) => q.questionId);
+    updateQuestionUsage(questionIds).catch((err) => {
+      console.error('Error updating question usage:', err);
+    });
 
     return successResponse(response);
   } catch (error) {

--- a/backend/src/handlers/processPdf.ts
+++ b/backend/src/handlers/processPdf.ts
@@ -262,6 +262,8 @@ export async function handler(event: S3Event): Promise<void> {
       duplicateCount: 0,
       createdAt: now,
       updatedAt: now,
+      source: 'pdf_extraction',
+      category: 'Laws of the Game',
     };
 
     await createExtractionJob(job);
@@ -323,6 +325,8 @@ export async function handler(event: S3Event): Promise<void> {
           hash,
           createdAt: now,
           updatedAt: now,
+          source: 'pdf_extraction',
+          usageCount: 0,
         };
 
         questionsToSave.push(question);

--- a/backend/src/lib/types.ts
+++ b/backend/src/lib/types.ts
@@ -28,6 +28,12 @@ export interface QuestionItem {
 // Question Bank types (extracted from PDFs)
 export type QuestionStatus = 'pending_review' | 'approved' | 'rejected';
 
+export type QuestionSource = 'pdf_extraction' | 'manual_entry' | 'seed_script';
+
+export type Difficulty = 'easy' | 'medium' | 'hard';
+
+export type JobSource = 'pdf_extraction' | 'manual_entry';
+
 export type Law =
   | 'Law 1' | 'Law 2' | 'Law 3' | 'Law 4' | 'Law 5'
   | 'Law 6' | 'Law 7' | 'Law 8' | 'Law 9' | 'Law 10'
@@ -54,6 +60,12 @@ export interface BankQuestionItem {
   updatedAt: string;
   reviewedAt?: string;
   reviewedBy?: string;
+  // New fields for manual entry and analytics
+  source?: QuestionSource; // 'pdf_extraction' | 'manual_entry' | 'seed_script'
+  difficulty?: Difficulty; // 'easy' | 'medium' | 'hard'
+  tags?: string[]; // Custom tags for categorization
+  usageCount?: number; // How many times served in quizzes (default: 0)
+  lastUsedAt?: string; // ISO timestamp of last usage
 }
 
 export type ExtractionJobStatus = 'pending' | 'processing' | 'completed' | 'failed';
@@ -76,6 +88,10 @@ export interface ExtractionJobItem {
   createdAt: string;
   updatedAt: string;
   completedAt?: string;
+  // New fields for manual entry
+  source?: JobSource; // 'pdf_extraction' | 'manual_entry'
+  description?: string; // Quiz description (for manual jobs)
+  category?: string; // Quiz category (default: 'Laws of the Game')
 }
 
 // API response types
@@ -120,6 +136,11 @@ export interface BankQuestion {
   createdAt: string;
   updatedAt: string;
   reviewedAt?: string;
+  source?: QuestionSource;
+  difficulty?: Difficulty;
+  tags?: string[];
+  usageCount?: number;
+  lastUsedAt?: string;
 }
 
 export interface ExtractionJob {
@@ -135,6 +156,9 @@ export interface ExtractionJob {
   errorMessage?: string;
   createdAt: string;
   completedAt?: string;
+  source?: JobSource;
+  description?: string;
+  category?: string;
 }
 
 // Claude extraction types

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,8 @@ import AdminJobs from './pages/admin/Jobs';
 import AdminJobDetail from './pages/admin/JobDetail';
 import AdminReview from './pages/admin/Review';
 import AdminQuestionBank from './pages/admin/QuestionBank';
+import AdminCreateQuiz from './pages/admin/CreateQuiz';
+import AdminAddQuestion from './pages/admin/AddQuestion';
 
 export default function App() {
   return (
@@ -23,8 +25,10 @@ export default function App() {
         <Route path="/admin" element={<AdminLayout />}>
           <Route index element={<AdminDashboard />} />
           <Route path="upload" element={<AdminUpload />} />
+          <Route path="create" element={<AdminCreateQuiz />} />
           <Route path="jobs" element={<AdminJobs />} />
           <Route path="jobs/:jobId" element={<AdminJobDetail />} />
+          <Route path="jobs/:jobId/add" element={<AdminAddQuestion />} />
           <Route path="review" element={<AdminReview />} />
           <Route path="questions" element={<AdminQuestionBank />} />
         </Route>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -11,6 +11,10 @@ import type {
   PublishResponse,
   QuestionStatus,
   Law,
+  CreateManualJobRequest,
+  CreateManualJobResponse,
+  AddManualQuestionRequest,
+  AddManualQuestionResponse,
 } from '../types';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
@@ -140,5 +144,25 @@ export async function publishQuiz(
   return fetchAPI<PublishResponse>(`/admin/jobs/${jobId}/publish`, {
     method: 'PUT',
     body: JSON.stringify({ publish }),
+  });
+}
+
+// Manual quiz creation endpoints
+export async function createManualJob(
+  request: CreateManualJobRequest
+): Promise<CreateManualJobResponse> {
+  return fetchAPI<CreateManualJobResponse>('/admin/jobs/manual', {
+    method: 'POST',
+    body: JSON.stringify(request),
+  });
+}
+
+export async function addManualQuestion(
+  jobId: string,
+  request: AddManualQuestionRequest
+): Promise<AddManualQuestionResponse> {
+  return fetchAPI<AddManualQuestionResponse>(`/admin/jobs/${jobId}/questions`, {
+    method: 'POST',
+    body: JSON.stringify(request),
   });
 }

--- a/frontend/src/pages/admin/AddQuestion.tsx
+++ b/frontend/src/pages/admin/AddQuestion.tsx
@@ -1,0 +1,378 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { addManualQuestion, getExtractionJob } from '../../api/client';
+import type { Law, Difficulty, ExtractionJob } from '../../types';
+
+const LAWS: Law[] = [
+  'Law 1', 'Law 2', 'Law 3', 'Law 4', 'Law 5',
+  'Law 6', 'Law 7', 'Law 8', 'Law 9', 'Law 10',
+  'Law 11', 'Law 12', 'Law 13', 'Law 14', 'Law 15',
+  'Law 16', 'Law 17',
+];
+
+const DIFFICULTIES: { value: Difficulty; label: string }[] = [
+  { value: 'easy', label: 'Easy' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'hard', label: 'Hard' },
+];
+
+export default function AddQuestion() {
+  const { jobId } = useParams<{ jobId: string }>();
+  const navigate = useNavigate();
+
+  const [job, setJob] = useState<ExtractionJob | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  // Form state
+  const [text, setText] = useState('');
+  const [options, setOptions] = useState(['', '', '', '']);
+  const [correctAnswer, setCorrectAnswer] = useState(0);
+  const [explanation, setExplanation] = useState('');
+  const [law, setLaw] = useState<Law>('Law 1');
+  const [lawReference, setLawReference] = useState('');
+  const [difficulty, setDifficulty] = useState<Difficulty | ''>('');
+  const [tagsInput, setTagsInput] = useState('');
+
+  useEffect(() => {
+    async function loadJob() {
+      if (!jobId) return;
+
+      try {
+        const data = await getExtractionJob(jobId);
+        setJob(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load job');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadJob();
+  }, [jobId]);
+
+  const handleOptionChange = (index: number, value: string) => {
+    const newOptions = [...options];
+    newOptions[index] = value;
+    setOptions(newOptions);
+  };
+
+  const resetForm = () => {
+    setText('');
+    setOptions(['', '', '', '']);
+    setCorrectAnswer(0);
+    setExplanation('');
+    setLawReference('');
+    setDifficulty('');
+    setTagsInput('');
+    // Keep the law selection for convenience when adding multiple questions
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!jobId) return;
+
+    // Validation
+    if (!text.trim()) {
+      setError('Question text is required');
+      return;
+    }
+
+    if (options.some((opt) => !opt.trim())) {
+      setError('All four options are required');
+      return;
+    }
+
+    if (!explanation.trim()) {
+      setError('Explanation is required');
+      return;
+    }
+
+    if (!lawReference.trim()) {
+      setError('Law reference is required');
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const tags = tagsInput
+        .split(',')
+        .map((tag) => tag.trim())
+        .filter((tag) => tag !== '');
+
+      await addManualQuestion(jobId, {
+        text: text.trim(),
+        options: options.map((opt) => opt.trim()),
+        correctAnswer,
+        explanation: explanation.trim(),
+        law,
+        lawReference: lawReference.trim(),
+        difficulty: difficulty || undefined,
+        tags: tags.length > 0 ? tags : undefined,
+      });
+
+      setSuccess('Question added successfully!');
+      resetForm();
+
+      // Update local job count
+      if (job) {
+        setJob({
+          ...job,
+          totalQuestions: job.totalQuestions + 1,
+          approvedCount: job.approvedCount + 1,
+        });
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add question');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="text-center">
+          <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+          <p className="mt-2 text-gray-600">Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!job) {
+    return (
+      <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
+        <p className="text-red-700">{error || 'Job not found'}</p>
+        <Link to="/admin/jobs" className="mt-4 inline-block btn-secondary">
+          Back to Jobs
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-8">
+        <Link
+          to={`/admin/jobs/${jobId}`}
+          className="text-sm text-gray-500 hover:text-gray-700 mb-2 inline-block"
+        >
+          ← Back to {job.fileName}
+        </Link>
+        <h1 className="text-2xl font-bold text-gray-900">Add Question</h1>
+        <p className="text-gray-600">
+          Adding to: <span className="font-medium">{job.fileName}</span>
+          <span className="ml-2 text-sm">
+            ({job.totalQuestions} questions)
+          </span>
+        </p>
+      </div>
+
+      <div className="bg-white rounded-lg shadow p-6 max-w-3xl">
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {error && (
+            <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+              <p className="text-red-700">{error}</p>
+            </div>
+          )}
+
+          {success && (
+            <div className="bg-green-50 border border-green-200 rounded-lg p-4">
+              <p className="text-green-700">{success}</p>
+            </div>
+          )}
+
+          {/* Question Text */}
+          <div>
+            <label
+              htmlFor="text"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Question Text *
+            </label>
+            <textarea
+              id="text"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              placeholder="Enter the question text..."
+              rows={3}
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              disabled={submitting}
+            />
+          </div>
+
+          {/* Options */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              Answer Options *
+            </label>
+            <div className="space-y-3">
+              {options.map((option, index) => (
+                <div key={index} className="flex items-center gap-3">
+                  <input
+                    type="radio"
+                    name="correctAnswer"
+                    checked={correctAnswer === index}
+                    onChange={() => setCorrectAnswer(index)}
+                    className="w-4 h-4 text-primary-600"
+                    disabled={submitting}
+                  />
+                  <span className="w-6 text-sm font-medium text-gray-500">
+                    {String.fromCharCode(65 + index)}.
+                  </span>
+                  <input
+                    type="text"
+                    value={option}
+                    onChange={(e) => handleOptionChange(index, e.target.value)}
+                    placeholder={`Option ${String.fromCharCode(65 + index)}`}
+                    className={`flex-1 px-4 py-2 border rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent ${
+                      correctAnswer === index
+                        ? 'border-green-300 bg-green-50'
+                        : 'border-gray-300'
+                    }`}
+                    disabled={submitting}
+                  />
+                  {correctAnswer === index && (
+                    <span className="text-green-600 text-sm font-medium">
+                      Correct
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+            <p className="mt-2 text-sm text-gray-500">
+              Select the radio button next to the correct answer
+            </p>
+          </div>
+
+          {/* Explanation */}
+          <div>
+            <label
+              htmlFor="explanation"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Explanation *
+            </label>
+            <textarea
+              id="explanation"
+              value={explanation}
+              onChange={(e) => setExplanation(e.target.value)}
+              placeholder="Explain why this is the correct answer..."
+              rows={3}
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              disabled={submitting}
+            />
+          </div>
+
+          {/* Law and Reference */}
+          <div className="grid md:grid-cols-2 gap-4">
+            <div>
+              <label
+                htmlFor="law"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Law *
+              </label>
+              <select
+                id="law"
+                value={law}
+                onChange={(e) => setLaw(e.target.value as Law)}
+                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                disabled={submitting}
+              >
+                {LAWS.map((l) => (
+                  <option key={l} value={l}>
+                    {l}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label
+                htmlFor="lawReference"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Law Reference *
+              </label>
+              <input
+                type="text"
+                id="lawReference"
+                value={lawReference}
+                onChange={(e) => setLawReference(e.target.value)}
+                placeholder="e.g., Law 12.1"
+                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                disabled={submitting}
+              />
+            </div>
+          </div>
+
+          {/* Difficulty and Tags */}
+          <div className="grid md:grid-cols-2 gap-4">
+            <div>
+              <label
+                htmlFor="difficulty"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Difficulty (optional)
+              </label>
+              <select
+                id="difficulty"
+                value={difficulty}
+                onChange={(e) => setDifficulty(e.target.value as Difficulty | '')}
+                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                disabled={submitting}
+              >
+                <option value="">Not specified</option>
+                {DIFFICULTIES.map((d) => (
+                  <option key={d.value} value={d.value}>
+                    {d.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label
+                htmlFor="tags"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Tags (optional)
+              </label>
+              <input
+                type="text"
+                id="tags"
+                value={tagsInput}
+                onChange={(e) => setTagsInput(e.target.value)}
+                placeholder="e.g., offside, VAR, penalty"
+                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                disabled={submitting}
+              />
+              <p className="mt-1 text-xs text-gray-500">
+                Comma-separated list of tags
+              </p>
+            </div>
+          </div>
+
+          <div className="flex gap-4 pt-4 border-t">
+            <button
+              type="submit"
+              disabled={submitting}
+              className="btn-primary disabled:opacity-50"
+            >
+              {submitting ? 'Adding...' : 'Add Question'}
+            </button>
+            <Link to={`/admin/jobs/${jobId}`} className="btn-secondary">
+              Done Adding
+            </Link>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/CreateQuiz.tsx
+++ b/frontend/src/pages/admin/CreateQuiz.tsx
@@ -1,0 +1,146 @@
+import { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { createManualJob } from '../../api/client';
+
+const CATEGORIES = [
+  'Laws of the Game',
+  'Practical Refereeing',
+  'Offside',
+  'Fouls and Misconduct',
+  'Set Pieces',
+  'General Knowledge',
+];
+
+export default function CreateQuiz() {
+  const navigate = useNavigate();
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [category, setCategory] = useState('Laws of the Game');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!title.trim()) {
+      setError('Title is required');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await createManualJob({
+        title: title.trim(),
+        description: description.trim() || undefined,
+        category,
+      });
+
+      // Navigate to the job detail page to add questions
+      navigate(`/admin/jobs/${response.jobId}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create quiz');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <div className="mb-8">
+        <Link
+          to="/admin"
+          className="text-sm text-gray-500 hover:text-gray-700 mb-2 inline-block"
+        >
+          ← Back to Dashboard
+        </Link>
+        <h1 className="text-2xl font-bold text-gray-900">Create Manual Quiz</h1>
+        <p className="text-gray-600">
+          Create a new quiz and add questions manually
+        </p>
+      </div>
+
+      <div className="bg-white rounded-lg shadow p-6 max-w-2xl">
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {error && (
+            <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+              <p className="text-red-700">{error}</p>
+            </div>
+          )}
+
+          <div>
+            <label
+              htmlFor="title"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Quiz Title *
+            </label>
+            <input
+              type="text"
+              id="title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="e.g., Law 12 - Fouls and Misconduct"
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              disabled={loading}
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="description"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Description
+            </label>
+            <textarea
+              id="description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="A brief description of what this quiz covers..."
+              rows={3}
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              disabled={loading}
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="category"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Category
+            </label>
+            <select
+              id="category"
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              disabled={loading}
+            >
+              {CATEGORIES.map((cat) => (
+                <option key={cat} value={cat}>
+                  {cat}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex gap-4">
+            <button
+              type="submit"
+              disabled={loading}
+              className="btn-primary disabled:opacity-50"
+            >
+              {loading ? 'Creating...' : 'Create Quiz'}
+            </button>
+            <Link to="/admin" className="btn-secondary">
+              Cancel
+            </Link>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/Dashboard.tsx
+++ b/frontend/src/pages/admin/Dashboard.tsx
@@ -182,6 +182,12 @@ export default function AdminDashboard() {
             Upload New PDF
           </Link>
           <Link
+            to="/admin/create"
+            className="px-4 py-2 rounded-lg font-medium bg-blue-600 text-white hover:bg-blue-700"
+          >
+            Create Manual Quiz
+          </Link>
+          <Link
             to="/admin/review"
             className="btn-secondary"
           >

--- a/frontend/src/pages/admin/JobDetail.tsx
+++ b/frontend/src/pages/admin/JobDetail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { getExtractionJob, reviewQuestion, publishQuiz } from '../../api/client';
-import type { JobDetailResponse, BankQuestion, QuestionStatus } from '../../types';
+import type { JobDetailResponse, BankQuestion, QuestionStatus, Difficulty } from '../../types';
 
 export default function AdminJobDetail() {
   const { jobId } = useParams<{ jobId: string }>();
@@ -109,11 +109,25 @@ export default function AdminJobDetail() {
         </Link>
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-gray-900">{job.fileName}</h1>
+            <div className="flex items-center gap-3 mb-1">
+              <h1 className="text-2xl font-bold text-gray-900">{job.fileName}</h1>
+              <SourceBadge source={job.source} />
+            </div>
             <p className="text-gray-500">Job ID: {job.jobId}</p>
+            {job.description && (
+              <p className="text-gray-600 mt-1">{job.description}</p>
+            )}
           </div>
           <div className="flex items-center gap-3">
             <StatusBadge status={job.status} />
+            {job.source === 'manual_entry' && (
+              <Link
+                to={`/admin/jobs/${job.jobId}/add`}
+                className="px-4 py-2 rounded-lg font-medium bg-blue-600 text-white hover:bg-blue-700"
+              >
+                Add Question
+              </Link>
+            )}
             {job.status === 'completed' && job.approvedCount > 0 && (
               <button
                 onClick={handlePublish}
@@ -211,12 +225,18 @@ function QuestionCard({
     <div className="px-6 py-4">
       <div className="flex items-start justify-between gap-4">
         <div className="flex-1">
-          <div className="flex items-center gap-2 mb-2">
+          <div className="flex items-center flex-wrap gap-2 mb-2">
             <span className="px-2 py-0.5 text-xs font-medium bg-blue-100 text-blue-800 rounded">
               {question.law}
             </span>
             <ConfidenceBadge confidence={question.confidence} />
             <QuestionStatusBadge status={question.status} />
+            {question.source && (
+              <SourceBadge source={question.source} />
+            )}
+            {question.difficulty && (
+              <DifficultyBadge difficulty={question.difficulty} />
+            )}
           </div>
           <p className="text-gray-900 mb-3">{question.text}</p>
           <div className="grid gap-2">
@@ -243,6 +263,18 @@ function QuestionCard({
             <p className="mt-3 text-sm text-gray-600">
               <span className="font-medium">Explanation:</span> {question.explanation}
             </p>
+          )}
+          {question.tags && question.tags.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-1">
+              {question.tags.map((tag, index) => (
+                <span
+                  key={index}
+                  className="px-2 py-0.5 text-xs bg-gray-100 text-gray-600 rounded"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
           )}
         </div>
         <div className="flex flex-col gap-2">
@@ -318,6 +350,46 @@ function ConfidenceBadge({ confidence }: { confidence: number }) {
   return (
     <span className={`px-2 py-0.5 text-xs font-medium rounded ${bgColor}`}>
       {percent}%
+    </span>
+  );
+}
+
+function SourceBadge({ source }: { source?: string }) {
+  if (!source || source === 'pdf_extraction') {
+    return (
+      <span className="px-2 py-0.5 text-xs font-medium rounded bg-purple-100 text-purple-700">
+        PDF
+      </span>
+    );
+  }
+
+  if (source === 'manual_entry') {
+    return (
+      <span className="px-2 py-0.5 text-xs font-medium rounded bg-blue-100 text-blue-700">
+        Manual
+      </span>
+    );
+  }
+
+  return (
+    <span className="px-2 py-0.5 text-xs font-medium rounded bg-gray-100 text-gray-700">
+      {source}
+    </span>
+  );
+}
+
+function DifficultyBadge({ difficulty }: { difficulty?: Difficulty }) {
+  if (!difficulty) return null;
+
+  const styles = {
+    easy: 'bg-green-100 text-green-700',
+    medium: 'bg-yellow-100 text-yellow-700',
+    hard: 'bg-red-100 text-red-700',
+  };
+
+  return (
+    <span className={`px-2 py-0.5 text-xs font-medium rounded ${styles[difficulty]}`}>
+      {difficulty}
     </span>
   );
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -34,6 +34,12 @@ export interface QuizResult {
 // Admin types
 export type QuestionStatus = 'pending_review' | 'approved' | 'rejected';
 
+export type QuestionSource = 'pdf_extraction' | 'manual_entry' | 'seed_script';
+
+export type Difficulty = 'easy' | 'medium' | 'hard';
+
+export type JobSource = 'pdf_extraction' | 'manual_entry';
+
 export type Law =
   | 'Law 1' | 'Law 2' | 'Law 3' | 'Law 4' | 'Law 5'
   | 'Law 6' | 'Law 7' | 'Law 8' | 'Law 9' | 'Law 10'
@@ -55,6 +61,11 @@ export interface BankQuestion {
   createdAt: string;
   updatedAt: string;
   reviewedAt?: string;
+  source?: QuestionSource;
+  difficulty?: Difficulty;
+  tags?: string[];
+  usageCount?: number;
+  lastUsedAt?: string;
 }
 
 export type ExtractionJobStatus = 'pending' | 'processing' | 'completed' | 'failed';
@@ -72,6 +83,9 @@ export interface ExtractionJob {
   errorMessage?: string;
   createdAt: string;
   completedAt?: string;
+  source?: JobSource;
+  description?: string;
+  category?: string;
 }
 
 export interface PresignedUrlResponse {
@@ -125,5 +139,33 @@ export interface BulkReviewResponse {
 export interface PublishResponse {
   jobId: string;
   published: boolean;
+  message: string;
+}
+
+// Manual quiz creation types
+export interface CreateManualJobRequest {
+  title: string;
+  description?: string;
+  category?: string;
+}
+
+export interface CreateManualJobResponse {
+  jobId: string;
+  message: string;
+}
+
+export interface AddManualQuestionRequest {
+  text: string;
+  options: string[];
+  correctAnswer: number;
+  explanation: string;
+  law: Law;
+  lawReference: string;
+  difficulty?: Difficulty;
+  tags?: string[];
+}
+
+export interface AddManualQuestionResponse {
+  questionId: string;
   message: string;
 }


### PR DESCRIPTION
## Summary

- Add ability to create quizzes manually from the admin UI without PDF extraction
- Enhanced metadata tracking for analytics (source, difficulty, tags, usage count)
- Track question usage when served in quizzes

## Changes

### Backend
- New handlers: `createManualJob` (POST /admin/jobs/manual), `addManualQuestion` (POST /admin/jobs/{id}/questions)
- Extended `BankQuestionItem` with `source`, `difficulty`, `tags`, `usageCount`, `lastUsedAt`
- Extended `ExtractionJobItem` with `source`, `description`, `category`
- Set `source: 'pdf_extraction'` on PDF-extracted questions
- Track question usage in `getQuestions` handler

### Infrastructure
- New Lambda functions for manual quiz endpoints
- New API Gateway routes with CORS
- Updated CI workflow to deploy new Lambda functions

### Frontend
- New `CreateQuiz` page at `/admin/create`
- New `AddQuestion` page at `/admin/jobs/{jobId}/add`
- Source badge (PDF/Manual) and Add Question button on JobDetail
- Difficulty and tags display on question cards
- "Create Manual Quiz" quick action on Dashboard

## Test plan

- [ ] Create a manual job via `/admin/create`
- [ ] Add 2-3 questions with different difficulties and tags
- [ ] Publish the quiz
- [ ] Verify it appears on home page
- [ ] Take the quiz and verify usage tracking updates
- [ ] Check that PDF extraction still works with `source: 'pdf_extraction'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)