### PR TITLE
fix: implement real submit answers API to fix quiz results

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -227,6 +227,7 @@ jobs:
       lambda_get_quizzes: ${{ steps.tf-output.outputs.lambda_get_quizzes }}
       lambda_get_quiz: ${{ steps.tf-output.outputs.lambda_get_quiz }}
       lambda_get_questions: ${{ steps.tf-output.outputs.lambda_get_questions }}
+      lambda_submit_answers: ${{ steps.tf-output.outputs.lambda_submit_answers }}
       lambda_generate_presigned_url: ${{ steps.tf-output.outputs.lambda_generate_presigned_url }}
       lambda_process_pdf: ${{ steps.tf-output.outputs.lambda_process_pdf }}
       lambda_get_question_bank: ${{ steps.tf-output.outputs.lambda_get_question_bank }}
@@ -264,6 +265,7 @@ jobs:
           echo "lambda_get_quizzes=$(terraform output -json lambda_function_names | jq -r '.get_quizzes')" >> $GITHUB_OUTPUT
           echo "lambda_get_quiz=$(terraform output -json lambda_function_names | jq -r '.get_quiz')" >> $GITHUB_OUTPUT
           echo "lambda_get_questions=$(terraform output -json lambda_function_names | jq -r '.get_questions')" >> $GITHUB_OUTPUT
+          echo "lambda_submit_answers=$(terraform output -json lambda_function_names | jq -r '.submit_answers')" >> $GITHUB_OUTPUT
           echo "lambda_generate_presigned_url=$(terraform output -json lambda_function_names | jq -r '.generate_presigned_url')" >> $GITHUB_OUTPUT
           echo "lambda_process_pdf=$(terraform output -json lambda_function_names | jq -r '.process_pdf')" >> $GITHUB_OUTPUT
           echo "lambda_get_question_bank=$(terraform output -json lambda_function_names | jq -r '.get_question_bank')" >> $GITHUB_OUTPUT
@@ -315,6 +317,13 @@ jobs:
           aws lambda update-function-code \
             --function-name ${{ needs.get-outputs.outputs.lambda_get_questions }} \
             --zip-file fileb://backend/dist/getQuestions.zip
+
+      - name: Update Lambda - submitAnswers
+        if: needs.get-outputs.outputs.lambda_submit_answers != '' && needs.get-outputs.outputs.lambda_submit_answers != 'null'
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ needs.get-outputs.outputs.lambda_submit_answers }} \
+            --zip-file fileb://backend/dist/submitAnswers.zip
 
       - name: Update Lambda - generatePresignedUrl
         run: |

--- a/.infra/modules/backend/outputs.tf
+++ b/.infra/modules/backend/outputs.tf
@@ -19,6 +19,7 @@ output "lambda_function_names" {
     get_quizzes            = aws_lambda_function.get_quizzes.function_name
     get_quiz               = aws_lambda_function.get_quiz.function_name
     get_questions          = aws_lambda_function.get_questions.function_name
+    submit_answers         = aws_lambda_function.submit_answers.function_name
     generate_presigned_url = aws_lambda_function.generate_presigned_url.function_name
     process_pdf            = aws_lambda_function.process_pdf.function_name
     get_question_bank      = aws_lambda_function.get_question_bank.function_name
@@ -36,6 +37,7 @@ output "lambda_function_arns" {
     get_quizzes            = aws_lambda_function.get_quizzes.arn
     get_quiz               = aws_lambda_function.get_quiz.arn
     get_questions          = aws_lambda_function.get_questions.arn
+    submit_answers         = aws_lambda_function.submit_answers.arn
     generate_presigned_url = aws_lambda_function.generate_presigned_url.arn
     process_pdf            = aws_lambda_function.process_pdf.arn
     get_question_bank      = aws_lambda_function.get_question_bank.arn

--- a/backend/build.js
+++ b/backend/build.js
@@ -14,6 +14,7 @@ const handlers = [
   'getQuizzes',
   'getQuiz',
   'getQuestions',
+  'submitAnswers',
   // Admin handlers
   'generatePresignedUrl',
   'processPdf',

--- a/backend/src/handlers/submitAnswers.ts
+++ b/backend/src/handlers/submitAnswers.ts
@@ -1,0 +1,118 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult, BankQuestionItem } from '../lib/types.js';
+import { getExtractionJob, getBankQuestion } from '../lib/dynamodb.js';
+import { successResponse, errorResponse } from '../lib/response.js';
+
+interface SubmitAnswersRequest {
+  answers: Array<{
+    questionId: string;
+    selectedOption: number;
+  }>;
+}
+
+interface QuestionResult {
+  questionId: string;
+  text: string;
+  options: string[];
+  selectedOption: number;
+  correctOption: number;
+  isCorrect: boolean;
+  explanation: string;
+  lawReference: string;
+}
+
+interface SubmitAnswersResponse {
+  results: QuestionResult[];
+  score: {
+    correct: number;
+    total: number;
+    percentage: number;
+  };
+}
+
+/**
+ * POST /quizzes/{id}/submit
+ * Submits quiz answers and returns results with correct answers
+ */
+export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  console.log('Event:', JSON.stringify(event, null, 2));
+
+  const quizId = event.pathParameters?.id;
+
+  if (!quizId) {
+    return errorResponse('Missing quiz ID', 400);
+  }
+
+  if (!event.body) {
+    return errorResponse('Request body is required', 400);
+  }
+
+  let request: SubmitAnswersRequest;
+  try {
+    request = JSON.parse(event.body);
+  } catch {
+    return errorResponse('Invalid JSON body', 400);
+  }
+
+  if (!request.answers || !Array.isArray(request.answers)) {
+    return errorResponse('answers array is required', 400);
+  }
+
+  try {
+    // Verify the quiz exists and is published
+    const job = await getExtractionJob(quizId);
+
+    if (!job || !job.published) {
+      return errorResponse('Quiz not found', 404);
+    }
+
+    // Fetch each question and build results
+    const results: QuestionResult[] = [];
+
+    for (const answer of request.answers) {
+      const question = await getBankQuestion(answer.questionId);
+
+      if (!question) {
+        // Skip questions that don't exist
+        console.warn(`Question not found: ${answer.questionId}`);
+        continue;
+      }
+
+      // Verify question belongs to this quiz
+      if (question.jobId !== quizId) {
+        console.warn(`Question ${answer.questionId} does not belong to quiz ${quizId}`);
+        continue;
+      }
+
+      const isCorrect = answer.selectedOption === question.correctAnswer;
+
+      results.push({
+        questionId: question.questionId,
+        text: question.text,
+        options: question.options,
+        selectedOption: answer.selectedOption,
+        correctOption: question.correctAnswer,
+        isCorrect,
+        explanation: question.explanation || 'No explanation available.',
+        lawReference: question.lawReference || question.law || 'N/A',
+      });
+    }
+
+    const correctCount = results.filter((r) => r.isCorrect).length;
+    const totalCount = results.length;
+    const percentage = totalCount > 0 ? Math.round((correctCount / totalCount) * 100) : 0;
+
+    const response: SubmitAnswersResponse = {
+      results,
+      score: {
+        correct: correctCount,
+        total: totalCount,
+        percentage,
+      },
+    };
+
+    return successResponse(response);
+  } catch (error) {
+    console.error('Error submitting answers:', error);
+    return errorResponse('Failed to submit answers', 500);
+  }
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2,6 +2,7 @@ import type {
   QuizSummary,
   QuizDetail,
   Question,
+  Answer,
   PresignedUrlResponse,
   QuestionBankResponse,
   JobsResponse,
@@ -15,6 +16,7 @@ import type {
   CreateManualJobResponse,
   AddManualQuestionRequest,
   AddManualQuestionResponse,
+  SubmitAnswersResponse,
 } from '../types';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
@@ -47,6 +49,16 @@ export async function getQuiz(quizId: string): Promise<QuizDetail> {
 
 export async function getQuestions(quizId: string, limit = 10): Promise<Question[]> {
   return fetchAPI<Question[]>(`/quizzes/${quizId}/questions?limit=${limit}`);
+}
+
+export async function submitAnswers(
+  quizId: string,
+  answers: Answer[]
+): Promise<SubmitAnswersResponse> {
+  return fetchAPI<SubmitAnswersResponse>(`/quizzes/${quizId}/submit`, {
+    method: 'POST',
+    body: JSON.stringify({ answers }),
+  });
 }
 
 // Admin endpoints

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -169,3 +169,28 @@ export interface AddManualQuestionResponse {
   questionId: string;
   message: string;
 }
+
+// Quiz submission types
+export interface SubmitAnswersRequest {
+  answers: Answer[];
+}
+
+export interface QuestionResultFromAPI {
+  questionId: string;
+  text: string;
+  options: string[];
+  selectedOption: number;
+  correctOption: number;
+  isCorrect: boolean;
+  explanation: string;
+  lawReference: string;
+}
+
+export interface SubmitAnswersResponse {
+  results: QuestionResultFromAPI[];
+  score: {
+    correct: number;
+    total: number;
+    percentage: number;
+  };
+}


### PR DESCRIPTION
## Summary
- Fixes critical bug where quiz results always showed option A as the correct answer
- The frontend was using mock data with hardcoded correctAnswer: 0
- Now properly calls a new backend endpoint that fetches real answers from the database

## Changes
- **Backend**: New submitAnswers.ts Lambda handler for POST /quizzes/{id}/submit
- **Infrastructure**: Terraform config for new Lambda and API Gateway route
- **CI**: Updated workflow to deploy new Lambda function
- **Frontend**: Rewritten QuizResults.tsx to call real API

## Test plan
- [ ] Take the Elite LOTG 2026 quiz (or any published quiz)
- [ ] Submit answers
- [ ] Verify the results page shows the correct answers matching what is shown in the admin panel
- [ ] Verify explanations and law references are displayed correctly

Generated with Claude Code