### PR TITLE
feat(auth): add Auth0 authentication to frontend

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,6 @@
 # API Gateway URL (from Terraform output)
 VITE_API_URL=https://your-api-gateway-url.amazonaws.com/prod
+
+# Auth0 Configuration
+VITE_AUTH0_DOMAIN=your-tenant.auth0.com
+VITE_AUTH0_CLIENT_ID=your-client-id

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "lotg-exams-frontend",
       "version": "1.0.0",
       "dependencies": {
+        "@auth0/auth0-react": "^2.11.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-dropzone": "^14.2.0",
@@ -40,6 +41,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@auth0/auth0-react": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-react/-/auth0-react-2.11.0.tgz",
+      "integrity": "sha512-UhUUNascMmzeSPEb+br7oL+StvXjSu9eEv7gT3+hwO2bAYWfOzY2wyDTwuMA7dmTW8JEfwSzhB7McFQLNHQEng==",
+      "license": "MIT",
+      "dependencies": {
+        "@auth0/auth0-spa-js": "^2.11.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17 || ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1",
+        "react-dom": "^16.11.0 || ^17 || ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
+      }
+    },
+    "node_modules/@auth0/auth0-spa-js": {
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.11.3.tgz",
+      "integrity": "sha512-gdivWytvbatuJ2MVWw2VouqV+dT975yJQXVwdap9d8Sa8KHsybjKoc5TbMqrECwZbXU+nCRIaaBRhL0aiKYA2A==",
+      "license": "MIT",
+      "dependencies": {
+        "browser-tabs-lock": "^1.2.15",
+        "dpop": "^2.1.1",
+        "es-cookie": "~1.3.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1842,6 +1867,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/browser-tabs-lock": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-tabs-lock/-/browser-tabs-lock-1.3.0.tgz",
+      "integrity": "sha512-g6nHaobTiT0eMZ7jh16YpD2kcjAp+PInbiVq3M1x6KKaEIVhT4v9oURNIpZLOZ3LQbQ3XYfNhMAb/9hzNLIWrw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": ">=4.17.21"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
@@ -2116,12 +2151,27 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dpop": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/dpop/-/dpop-2.1.1.tgz",
+      "integrity": "sha512-J0Of2JTiM4h5si0tlbPQ/lkqfZ5wAEVkKYBhkwyyANnPJfWH4VsR5uIkZ+T+OSPIwDYUg1fbd5Mmodd25HjY1w==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
       "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-cookie": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/es-cookie/-/es-cookie-1.3.2.tgz",
+      "integrity": "sha512-UTlYYhXGLOy05P/vKVT2Ui7WtC7NiRzGtJyAKKn32g5Gvcjn7KAClLPWlipCtxIus934dFg9o9jXiBL0nP+t9Q==",
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -2973,6 +3023,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint src --ext ts,tsx"
   },
   "dependencies": {
+    "@auth0/auth0-react": "^2.11.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,6 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom';
+import Layout from './components/Layout';
+import ProtectedRoute from './components/ProtectedRoute';
 import QuizList from './pages/QuizList';
 import QuizTake from './pages/QuizTake';
 import QuizResults from './pages/QuizResults';
@@ -14,25 +16,32 @@ import AdminAddQuestion from './pages/admin/AddQuestion';
 
 export default function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        {/* Public quiz routes */}
+    <Routes>
+      {/* Public routes with Navbar */}
+      <Route element={<Layout />}>
         <Route path="/" element={<QuizList />} />
         <Route path="/quiz/:quizId" element={<QuizTake />} />
         <Route path="/quiz/:quizId/results" element={<QuizResults />} />
+      </Route>
 
-        {/* Admin routes */}
-        <Route path="/admin" element={<AdminLayout />}>
-          <Route index element={<AdminDashboard />} />
-          <Route path="upload" element={<AdminUpload />} />
-          <Route path="create" element={<AdminCreateQuiz />} />
-          <Route path="jobs" element={<AdminJobs />} />
-          <Route path="jobs/:jobId" element={<AdminJobDetail />} />
-          <Route path="jobs/:jobId/add" element={<AdminAddQuestion />} />
-          <Route path="review" element={<AdminReview />} />
-          <Route path="questions" element={<AdminQuestionBank />} />
-        </Route>
-      </Routes>
-    </BrowserRouter>
+      {/* Protected admin routes */}
+      <Route
+        path="/admin"
+        element={
+          <ProtectedRoute>
+            <AdminLayout />
+          </ProtectedRoute>
+        }
+      >
+        <Route index element={<AdminDashboard />} />
+        <Route path="upload" element={<AdminUpload />} />
+        <Route path="create" element={<AdminCreateQuiz />} />
+        <Route path="jobs" element={<AdminJobs />} />
+        <Route path="jobs/:jobId" element={<AdminJobDetail />} />
+        <Route path="jobs/:jobId/add" element={<AdminAddQuestion />} />
+        <Route path="review" element={<AdminReview />} />
+        <Route path="questions" element={<AdminQuestionBank />} />
+      </Route>
+    </Routes>
   );
 }

--- a/frontend/src/components/AdminLayout.tsx
+++ b/frontend/src/components/AdminLayout.tsx
@@ -1,4 +1,5 @@
 import { NavLink, Outlet } from 'react-router-dom';
+import { useAuth0 } from '@auth0/auth0-react';
 
 const navItems = [
   { to: '/admin', label: 'Dashboard', end: true },
@@ -9,6 +10,8 @@ const navItems = [
 ];
 
 export default function AdminLayout() {
+  const { user, logout } = useAuth0();
+
   return (
     <div className="min-h-screen bg-gray-50">
       <header className="bg-white border-b border-gray-200">
@@ -22,24 +25,44 @@ export default function AdminLayout() {
                 Admin
               </span>
             </div>
-            <nav className="flex items-center gap-1">
-              {navItems.map((item) => (
-                <NavLink
-                  key={item.to}
-                  to={item.to}
-                  end={item.end}
-                  className={({ isActive }) =>
-                    `px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-                      isActive
-                        ? 'bg-primary-100 text-primary-700'
-                        : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
-                    }`
-                  }
+            <div className="flex items-center gap-4">
+              <nav className="flex items-center gap-1">
+                {navItems.map((item) => (
+                  <NavLink
+                    key={item.to}
+                    to={item.to}
+                    end={item.end}
+                    className={({ isActive }) =>
+                      `px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                        isActive
+                          ? 'bg-primary-100 text-primary-700'
+                          : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                      }`
+                    }
+                  >
+                    {item.label}
+                  </NavLink>
+                ))}
+              </nav>
+              <div className="flex items-center gap-3 ml-4 pl-4 border-l border-gray-200">
+                {user?.picture && (
+                  <img
+                    src={user.picture}
+                    alt={user.name || 'User'}
+                    className="h-8 w-8 rounded-full"
+                  />
+                )}
+                <span className="text-sm text-gray-700 hidden sm:block">
+                  {user?.name || user?.email}
+                </span>
+                <button
+                  onClick={() => logout({ logoutParams: { returnTo: window.location.origin } })}
+                  className="btn btn-secondary text-sm"
                 >
-                  {item.label}
-                </NavLink>
-              ))}
-            </nav>
+                  Log Out
+                </button>
+              </div>
+            </div>
           </div>
         </div>
       </header>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from 'react-router-dom';
+import Navbar from './Navbar';
+
+export default function Layout() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navbar />
+      <main>
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,0 +1,58 @@
+import { Link } from 'react-router-dom';
+import { useAuth0 } from '@auth0/auth0-react';
+
+export default function Navbar() {
+  const { isAuthenticated, isLoading, user, loginWithRedirect, logout } = useAuth0();
+
+  return (
+    <header className="bg-white border-b border-gray-200 sticky top-0 z-50">
+      <div className="container mx-auto px-4">
+        <div className="flex items-center justify-between h-16">
+          <Link
+            to="/"
+            className="text-xl font-bold text-gray-900 hover:text-primary-600 transition-colors"
+          >
+            LOTG Exams
+          </Link>
+
+          <nav className="flex items-center gap-4">
+            {isLoading ? (
+              <div className="h-8 w-8 animate-pulse bg-gray-200 rounded-full" />
+            ) : isAuthenticated ? (
+              <>
+                <Link
+                  to="/admin"
+                  className="px-3 py-2 text-sm font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-md transition-colors"
+                >
+                  Admin
+                </Link>
+                <div className="flex items-center gap-3">
+                  {user?.picture && (
+                    <img
+                      src={user.picture}
+                      alt={user.name || 'User'}
+                      className="h-8 w-8 rounded-full"
+                    />
+                  )}
+                  <span className="text-sm text-gray-700 hidden sm:block">
+                    {user?.name || user?.email}
+                  </span>
+                  <button
+                    onClick={() => logout({ logoutParams: { returnTo: window.location.origin } })}
+                    className="btn btn-secondary text-sm"
+                  >
+                    Log Out
+                  </button>
+                </div>
+              </>
+            ) : (
+              <button onClick={() => loginWithRedirect()} className="btn btn-primary text-sm">
+                Log In
+              </button>
+            )}
+          </nav>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,29 @@
+import { useAuth0 } from '@auth0/auth0-react';
+import { Navigate, useLocation } from 'react-router-dom';
+
+interface ProtectedRouteProps {
+  children: React.ReactNode;
+}
+
+export default function ProtectedRoute({ children }: ProtectedRouteProps) {
+  const { isAuthenticated, isLoading } = useAuth0();
+  const location = useLocation();
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600"></div>
+          <p className="mt-4 text-gray-600">Checking authentication...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    // Redirect to home page, preserving the intended destination
+    return <Navigate to="/" state={{ from: location }} replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -1,0 +1,168 @@
+import { useAuth0 } from '@auth0/auth0-react';
+import { useCallback } from 'react';
+import type {
+  QuestionBankResponse,
+  JobsResponse,
+  JobDetailResponse,
+  ReviewResponse,
+  BulkReviewResponse,
+  PublishResponse,
+  QuestionStatus,
+  Law,
+  CreateManualJobRequest,
+  CreateManualJobResponse,
+  AddManualQuestionRequest,
+  AddManualQuestionResponse,
+  PresignedUrlResponse,
+} from '../types';
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
+
+/**
+ * Hook that provides authenticated API functions.
+ * Use this for admin endpoints that require authentication.
+ */
+export function useApi() {
+  const { getAccessTokenSilently, isAuthenticated } = useAuth0();
+
+  const fetchWithAuth = useCallback(
+    async <T>(endpoint: string, options?: RequestInit): Promise<T> => {
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        ...((options?.headers as Record<string, string>) || {}),
+      };
+
+      // Add auth header if authenticated
+      if (isAuthenticated) {
+        try {
+          const token = await getAccessTokenSilently();
+          headers['Authorization'] = `Bearer ${token}`;
+        } catch {
+          // Token fetch failed, continue without auth
+          console.warn('Failed to get access token');
+        }
+      }
+
+      const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+        ...options,
+        headers,
+      });
+
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({ error: 'Unknown error' }));
+        throw new Error(error.error || `HTTP ${response.status}`);
+      }
+
+      return response.json();
+    },
+    [getAccessTokenSilently, isAuthenticated]
+  );
+
+  // Admin endpoints with authentication
+  const getPresignedUrl = useCallback(
+    (fileName: string): Promise<PresignedUrlResponse> => {
+      return fetchWithAuth<PresignedUrlResponse>('/admin/upload/presigned-url', {
+        method: 'POST',
+        body: JSON.stringify({
+          fileName,
+          contentType: 'application/pdf',
+        }),
+      });
+    },
+    [fetchWithAuth]
+  );
+
+  const getQuestionBank = useCallback(
+    (params?: {
+      law?: Law;
+      status?: QuestionStatus;
+      limit?: number;
+    }): Promise<QuestionBankResponse> => {
+      const searchParams = new URLSearchParams();
+      if (params?.law) searchParams.set('law', params.law);
+      if (params?.status) searchParams.set('status', params.status);
+      if (params?.limit) searchParams.set('limit', params.limit.toString());
+
+      const query = searchParams.toString();
+      return fetchWithAuth<QuestionBankResponse>(`/admin/questions${query ? `?${query}` : ''}`);
+    },
+    [fetchWithAuth]
+  );
+
+  const getExtractionJobs = useCallback((): Promise<JobsResponse> => {
+    return fetchWithAuth<JobsResponse>('/admin/jobs');
+  }, [fetchWithAuth]);
+
+  const getExtractionJob = useCallback(
+    (jobId: string): Promise<JobDetailResponse> => {
+      return fetchWithAuth<JobDetailResponse>(`/admin/jobs/${jobId}`);
+    },
+    [fetchWithAuth]
+  );
+
+  const reviewQuestion = useCallback(
+    (questionId: string, status: QuestionStatus, reviewedBy?: string): Promise<ReviewResponse> => {
+      return fetchWithAuth<ReviewResponse>(`/admin/questions/${questionId}/review`, {
+        method: 'PUT',
+        body: JSON.stringify({ status, reviewedBy }),
+      });
+    },
+    [fetchWithAuth]
+  );
+
+  const bulkReviewQuestions = useCallback(
+    (
+      questionIds: string[],
+      status: QuestionStatus,
+      reviewedBy?: string
+    ): Promise<BulkReviewResponse> => {
+      return fetchWithAuth<BulkReviewResponse>('/admin/questions/bulk-review', {
+        method: 'POST',
+        body: JSON.stringify({ questionIds, status, reviewedBy }),
+      });
+    },
+    [fetchWithAuth]
+  );
+
+  const publishQuiz = useCallback(
+    (jobId: string, publish = true): Promise<PublishResponse> => {
+      return fetchWithAuth<PublishResponse>(`/admin/jobs/${jobId}/publish`, {
+        method: 'PUT',
+        body: JSON.stringify({ publish }),
+      });
+    },
+    [fetchWithAuth]
+  );
+
+  const createManualJob = useCallback(
+    (request: CreateManualJobRequest): Promise<CreateManualJobResponse> => {
+      return fetchWithAuth<CreateManualJobResponse>('/admin/jobs/manual', {
+        method: 'POST',
+        body: JSON.stringify(request),
+      });
+    },
+    [fetchWithAuth]
+  );
+
+  const addManualQuestion = useCallback(
+    (jobId: string, request: AddManualQuestionRequest): Promise<AddManualQuestionResponse> => {
+      return fetchWithAuth<AddManualQuestionResponse>(`/admin/jobs/${jobId}/questions`, {
+        method: 'POST',
+        body: JSON.stringify(request),
+      });
+    },
+    [fetchWithAuth]
+  );
+
+  return {
+    getPresignedUrl,
+    getQuestionBank,
+    getExtractionJobs,
+    getExtractionJob,
+    reviewQuestion,
+    bulkReviewQuestions,
+    publishQuiz,
+    createManualJob,
+    addManualQuestion,
+  };
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,30 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import { Auth0Provider } from '@auth0/auth0-react';
 import App from './App';
 import './styles/index.css';
 
+const domain = import.meta.env.VITE_AUTH0_DOMAIN;
+const clientId = import.meta.env.VITE_AUTH0_CLIENT_ID;
+
+if (!domain || !clientId) {
+  console.error('Auth0 configuration missing. Please check your .env file.');
+  console.error('Required: VITE_AUTH0_DOMAIN, VITE_AUTH0_CLIENT_ID');
+}
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <Auth0Provider
+        domain={domain}
+        clientId={clientId}
+        authorizationParams={{
+          redirect_uri: window.location.origin,
+        }}
+      >
+        <App />
+      </Auth0Provider>
+    </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- Add Auth0 authentication to the React frontend
- Protect admin routes behind login
- Add login/logout UI to public pages and admin layout

## Changes

### New Files
- `src/components/Navbar.tsx` - Navigation bar with login/logout buttons
- `src/components/Layout.tsx` - Public page layout with Navbar
- `src/components/ProtectedRoute.tsx` - HOC to protect routes requiring auth
- `src/hooks/useApi.ts` - Hook providing authenticated API functions

### Modified Files
- `src/main.tsx` - Wrap app with Auth0Provider and BrowserRouter
- `src/App.tsx` - Use Layout for public routes, ProtectedRoute for admin
- `src/components/AdminLayout.tsx` - Add user info and logout button
- `.env.example` - Add Auth0 configuration variables

## Auth0 Configuration
```
VITE_AUTH0_DOMAIN=dev-ny08ciyqmnstuox3.eu.auth0.com
VITE_AUTH0_CLIENT_ID=QG8HrMMpbAUXX24mRp4Uy3zCtx3NDWBD
```

## Test plan
- [ ] Visit homepage - should see "Log In" button in navbar
- [ ] Click "Log In" - should redirect to Auth0 login page
- [ ] Login with Google - should redirect back, show user avatar
- [ ] Click "Admin" link - should access admin dashboard
- [ ] Click "Log Out" - should return to homepage as unauthenticated
- [ ] Visit /admin directly when logged out - should redirect to homepage

## Notes
- Backend JWT verification (API Gateway authorizer) is Phase 2.3
- For now, admin routes are protected on frontend only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
