### PR TITLE
fix(ci): add Auth0 environment variables to frontend build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -422,6 +422,8 @@ jobs:
       - name: Build Frontend
         env:
           VITE_API_URL: ${{ needs.get-outputs.outputs.api_url }}
+          VITE_AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
+          VITE_AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
         run: npm run build
 
       - name: Configure AWS Credentials


### PR DESCRIPTION
## Summary
Fix Auth0 login showing `undefined` domain in production by passing Auth0 environment variables during frontend build.

## Problem
The Auth0 domain and client ID weren't being passed to the Vite build in CI/CD, resulting in `undefined` values in production.

## Solution
Add `VITE_AUTH0_DOMAIN` and `VITE_AUTH0_CLIENT_ID` environment variables to the frontend build step, sourced from GitHub secrets.

## Required Action
**Before merging**, add these GitHub secrets to the repository:

1. Go to **Settings → Secrets and variables → Actions**
2. Add **Repository secrets**:
   - `AUTH0_DOMAIN` - Your Auth0 tenant domain (from Auth0 dashboard)
   - `AUTH0_CLIENT_ID` - Your Auth0 application client ID (from Auth0 dashboard)

## Test plan
- [ ] Add GitHub secrets (see above)
- [ ] Merge PR
- [ ] Wait for deployment
- [ ] Click "Log In" - should redirect to Auth0, not `undefined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
