### PR TITLE
fix(auth): trigger frontend rebuild with Auth0 env vars

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,9 +8,11 @@ import './styles/index.css';
 const domain = import.meta.env.VITE_AUTH0_DOMAIN;
 const clientId = import.meta.env.VITE_AUTH0_CLIENT_ID;
 
+// Validate Auth0 configuration at startup
 if (!domain || !clientId) {
-  console.error('Auth0 configuration missing. Please check your .env file.');
-  console.error('Required: VITE_AUTH0_DOMAIN, VITE_AUTH0_CLIENT_ID');
+  console.error(
+    'Auth0 configuration missing. Ensure VITE_AUTH0_DOMAIN and VITE_AUTH0_CLIENT_ID are set.'
+  );
 }
 
 ReactDOM.createRoot(document.getElementById('root')!).render(


### PR DESCRIPTION
## Summary
Trigger frontend rebuild to pick up Auth0 environment variables from GitHub secrets.

## Why
The previous PR (#19) added Auth0 env vars to the workflow, but only workflow files changed, so the frontend was not rebuilt.

## Changes
- Minor improvement to Auth0 config validation message in main.tsx

## Test plan
- [ ] After merge, verify frontend deployment runs
- [ ] Visit site and click "Log In" - should redirect to Auth0 (not undefined)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
