### PR TITLE
feat(auth): add role-based access control for admin routes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,7 +28,7 @@ export default function App() {
       <Route
         path="/admin"
         element={
-          <ProtectedRoute>
+          <ProtectedRoute requiredRole="admin">
             <AdminLayout />
           </ProtectedRoute>
         }

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,8 +1,10 @@
 import { Link } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
+import { useRoles } from '../hooks/useRoles';
 
 export default function Navbar() {
   const { isAuthenticated, isLoading, user, loginWithRedirect, logout } = useAuth0();
+  const { isAdmin } = useRoles();
 
   return (
     <header className="bg-white border-b border-gray-200 sticky top-0 z-50">
@@ -20,12 +22,14 @@ export default function Navbar() {
               <div className="h-8 w-8 animate-pulse bg-gray-200 rounded-full" />
             ) : isAuthenticated ? (
               <>
-                <Link
-                  to="/admin"
-                  className="px-3 py-2 text-sm font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-md transition-colors"
-                >
-                  Admin
-                </Link>
+                {isAdmin && (
+                  <Link
+                    to="/admin"
+                    className="px-3 py-2 text-sm font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-md transition-colors"
+                  >
+                    Admin
+                  </Link>
+                )}
                 <div className="flex items-center gap-3">
                   {user?.picture && (
                     <img

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,12 +1,15 @@
 import { useAuth0 } from '@auth0/auth0-react';
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate, useLocation, Link } from 'react-router-dom';
+import { useRoles } from '../hooks/useRoles';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
+  requiredRole?: string;
 }
 
-export default function ProtectedRoute({ children }: ProtectedRouteProps) {
+export default function ProtectedRoute({ children, requiredRole }: ProtectedRouteProps) {
   const { isAuthenticated, isLoading } = useAuth0();
+  const { roles } = useRoles();
   const location = useLocation();
 
   if (isLoading) {
@@ -23,6 +26,20 @@ export default function ProtectedRoute({ children }: ProtectedRouteProps) {
   if (!isAuthenticated) {
     // Redirect to home page, preserving the intended destination
     return <Navigate to="/" state={{ from: location }} replace />;
+  }
+
+  if (requiredRole && !roles.includes(requiredRole)) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-gray-900 mb-4">Access Denied</h1>
+          <p className="text-gray-600 mb-6">You don't have permission to access this page.</p>
+          <Link to="/" className="btn btn-primary">
+            Go Home
+          </Link>
+        </div>
+      </div>
+    );
   }
 
   return <>{children}</>;

--- a/frontend/src/hooks/useRoles.ts
+++ b/frontend/src/hooks/useRoles.ts
@@ -1,0 +1,12 @@
+import { useAuth0 } from '@auth0/auth0-react';
+
+const ROLES_NAMESPACE = 'https://lotg-exams.com/roles';
+
+export function useRoles() {
+  const { user, isAuthenticated } = useAuth0();
+
+  const roles: string[] = user?.[ROLES_NAMESPACE] || [];
+  const isAdmin = roles.includes('admin');
+
+  return { roles, isAdmin, isAuthenticated };
+}


### PR DESCRIPTION
## Summary
- Add `useRoles` hook to extract roles from Auth0 token using `https://lotg-exams.com/roles` namespace
- Update `ProtectedRoute` component to support `requiredRole` prop with "Access Denied" page for unauthorized users
- Conditionally show Admin link in navbar only for users with admin role
- Require admin role for all `/admin` routes

## Test plan
- [ ] Login as admin user → can see Admin link → can access /admin
- [ ] Login as regular user → NO Admin link → /admin shows "Access Denied"
- [ ] Logout → NO Admin link → /admin redirects to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)