### PR TITLE
fix(infra): add 3-day retention to CloudWatch log groups

### DIFF
--- a/.infra/modules/backend/main.tf
+++ b/.infra/modules/backend/main.tf
@@ -1,3 +1,31 @@
+# ============================================================================
+# CloudWatch Log Groups (3-day retention for cost optimization)
+# ============================================================================
+
+locals {
+  lambda_functions = [
+    "getQuizzes",
+    "getQuiz",
+    "getQuestions",
+    "submitAnswers",
+    "generatePresignedUrl",
+    "processPdf",
+    "getQuestionBank",
+    "reviewQuestion",
+    "bulkReviewQuestions",
+    "publishQuiz",
+    "getExtractionJobs",
+    "createManualJob",
+    "addManualQuestion",
+  ]
+}
+
+resource "aws_cloudwatch_log_group" "lambda" {
+  for_each          = toset(local.lambda_functions)
+  name              = "/aws/lambda/${var.project_name}-${var.environment}-${each.value}"
+  retention_in_days = 3
+}
+
 # IAM role for Lambda execution
 resource "aws_iam_role" "lambda" {
   name = "${var.project_name}-${var.environment}-lambda-exec"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,10 @@ Follow AWS Well-Architected Framework principles:
 - Use least-privilege IAM policies - only grant permissions needed
 - Enable encryption at rest for all data stores
 - Use `terraform fmt` before committing
+- **Keep Terraform DRY** - use `for_each`, `locals`, and modules to avoid repetition
+- **Lambda log groups**: Always create a corresponding `aws_cloudwatch_log_group` with
+  `retention_in_days = 3` when adding Lambda functions (add to `local.lambda_functions`
+  in `.infra/modules/backend/main.tf`)
 
 ### Naming Conventions
 


### PR DESCRIPTION
## Summary
- Add CloudWatch log group resources for all Lambda functions with 3-day retention
- Uses `for_each` to keep configuration DRY (single resource block)
- Add CLAUDE.md guidelines for future Lambda functions

## Changes
- `.infra/modules/backend/main.tf`: Add `local.lambda_functions` list and single
  `aws_cloudwatch_log_group.lambda` resource with `for_each`
- `CLAUDE.md`: Document requirement to add log groups for new Lambdas

## Adding New Lambda Functions
When adding a new Lambda, add its name to `local.lambda_functions` in
`.infra/modules/backend/main.tf` to automatically create a log group with 3-day retention.

## Test plan
- [x] Delete existing log groups in AWS Console
- [ ] Run `terraform apply` to create log groups with 3-day retention
- [ ] Verify retention setting in AWS Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)