### PR TITLE
feat(quiz): add confetti celebration on quiz results

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,12 +9,14 @@
       "version": "1.0.0",
       "dependencies": {
         "@auth0/auth0-react": "^2.11.0",
+        "canvas-confetti": "^1.9.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-dropzone": "^14.2.0",
         "react-router-dom": "^6.21.0"
       },
       "devDependencies": {
+        "@types/canvas-confetti": "^1.9.0",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
@@ -1388,6 +1390,13 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/canvas-confetti": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@types/canvas-confetti/-/canvas-confetti-1.9.0.tgz",
+      "integrity": "sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1951,6 +1960,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.4.tgz",
+      "integrity": "sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,12 +11,14 @@
   },
   "dependencies": {
     "@auth0/auth0-react": "^2.11.0",
+    "canvas-confetti": "^1.9.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.0",
     "react-router-dom": "^6.21.0"
   },
   "devDependencies": {
+    "@types/canvas-confetti": "^1.9.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",


### PR DESCRIPTION
## Summary
- Add `canvas-confetti` package for score-based celebrations
- 90%+ score: Continuous confetti explosion from both sides (green theme)
- 70-89% score: Single confetti burst (blue theme)
- Below 70%: Encouraging message only (no confetti)
- Add score-appropriate feedback messages

## Implementation
| Score | Animation | Message |
|-------|-----------|---------|
| 90%+ | Big confetti explosion (3 seconds) | "Excellent work! You really know the Laws of the Game!" |
| 70-89% | Medium celebration burst | "Good job! Keep studying to master the Laws!" |
| <70% | No confetti | "Keep practicing! Review the Laws and try again." |

## Test plan
- [ ] Complete quiz with 90%+ score → see continuous confetti + green message
- [ ] Complete quiz with 70-89% score → see single burst + blue message
- [ ] Complete quiz with <70% score → no confetti + amber encouraging message
- [ ] Test on mobile devices

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)