### PR TITLE
feat(auth): add API Gateway JWT authorizer for admin routes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,8 @@ env:
   AWS_ROLE_ARN: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/lotg-exams-github-actions
   TF_VERSION: 1.6.0
   NODE_VERSION: 20
+  TF_VAR_auth0_domain: ${{ secrets.AUTH0_DOMAIN }}
+  TF_VAR_auth0_audience: ${{ secrets.AUTH0_AUDIENCE }}
 
 jobs:
   # Detect which folders have changes

--- a/.infra/main.tf
+++ b/.infra/main.tf
@@ -26,6 +26,8 @@ module "backend" {
   environment         = var.environment
   dynamodb_table_name = module.database.table_name
   dynamodb_table_arn  = module.database.table_arn
+  auth0_domain        = var.auth0_domain
+  auth0_audience      = var.auth0_audience
 }
 
 # Frontend module - S3 + CloudFront

--- a/.infra/modules/backend/outputs.tf
+++ b/.infra/modules/backend/outputs.tf
@@ -29,6 +29,7 @@ output "lambda_function_names" {
     publish_quiz           = aws_lambda_function.publish_quiz.function_name
     create_manual_job      = aws_lambda_function.create_manual_job.function_name
     add_manual_question    = aws_lambda_function.add_manual_question.function_name
+    authorize              = aws_lambda_function.authorize.function_name
   }
 }
 
@@ -48,6 +49,7 @@ output "lambda_function_arns" {
     publish_quiz           = aws_lambda_function.publish_quiz.arn
     create_manual_job      = aws_lambda_function.create_manual_job.arn
     add_manual_question    = aws_lambda_function.add_manual_question.arn
+    authorize              = aws_lambda_function.authorize.arn
   }
 }
 

--- a/.infra/modules/backend/variables.tf
+++ b/.infra/modules/backend/variables.tf
@@ -26,3 +26,15 @@ variable "dynamodb_table_arn" {
   type        = string
   nullable    = false
 }
+
+variable "auth0_domain" {
+  description = "Auth0 domain (e.g., your-tenant.auth0.com)"
+  type        = string
+  nullable    = false
+}
+
+variable "auth0_audience" {
+  description = "Auth0 API audience identifier"
+  type        = string
+  nullable    = false
+}

--- a/.infra/variables.tf
+++ b/.infra/variables.tf
@@ -36,3 +36,15 @@ variable "environment" {
 
   nullable = false
 }
+
+variable "auth0_domain" {
+  description = "Auth0 domain (e.g., your-tenant.auth0.com)"
+  type        = string
+  nullable    = false
+}
+
+variable "auth0_audience" {
+  description = "Auth0 API audience identifier"
+  type        = string
+  nullable    = false
+}

--- a/backend/build.js
+++ b/backend/build.js
@@ -26,6 +26,8 @@ const handlers = [
   // Manual quiz creation handlers
   'createManualJob',
   'addManualQuestion',
+  // Auth
+  'authorize',
 ];
 
 async function buildHandler(handlerName) {
@@ -74,23 +76,21 @@ async function main() {
   await mkdir('dist', { recursive: true });
 
   // Build all handlers
-  const buildResults = await Promise.all(
-    handlers.map(handler => buildHandler(handler))
-  );
+  const buildResults = await Promise.all(handlers.map((handler) => buildHandler(handler)));
 
-  if (buildResults.some(result => !result)) {
+  if (buildResults.some((result) => !result)) {
     console.error('\n✗ Some builds failed');
     process.exit(1);
   }
 
   // Zip all handlers
   console.log('\nZipping Lambda functions...\n');
-  await Promise.all(handlers.map(handler => zipHandler(handler)));
+  await Promise.all(handlers.map((handler) => zipHandler(handler)));
 
   console.log('\n✓ All Lambda functions built and zipped successfully');
 }
 
-main().catch(error => {
+main().catch((error) => {
   console.error('Build failed:', error);
   process.exit(1);
 });

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,10 +14,13 @@
         "@aws-sdk/client-secrets-manager": "^3.490.0",
         "@aws-sdk/lib-dynamodb": "^3.490.0",
         "@aws-sdk/s3-request-presigner": "^3.490.0",
+        "jsonwebtoken": "^9.0.3",
+        "jwks-rsa": "^3.2.2",
         "ulid": "^2.3.0"
       },
       "devDependencies": {
         "@types/archiver": "^6.0.0",
+        "@types/jsonwebtoken": "^9.0.10",
         "archiver": "^6.0.0",
         "esbuild": "^0.19.0"
       }
@@ -2965,6 +2968,22 @@
         "@types/readdir-glob": "*"
       }
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "18.19.130",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
@@ -3131,6 +3150,12 @@
         "node": "*"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -3156,6 +3181,23 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -3177,6 +3219,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/es-define-property": {
@@ -3536,6 +3587,149 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jwks-rsa": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-3.2.2.tgz",
+      "integrity": "sha512-BqTyEDV+lS8F2trk3A+qJnxV5Q9EqKCBJOPti3W97r7qTympCZjb7h2X6f2kc+0K3rsSTY1/6YG2eaXKoj497w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "^9.0.4",
+        "debug": "^4.3.4",
+        "jose": "^4.15.4",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lru-memoizer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.3.0.tgz",
+      "integrity": "sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "6.0.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3714,7 +3908,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3730,6 +3923,18 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/streamx": {
       "version": "2.23.0",
@@ -3859,6 +4064,12 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
     },
     "node_modules/zip-stream": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,10 +14,13 @@
     "@aws-sdk/client-secrets-manager": "^3.490.0",
     "@aws-sdk/lib-dynamodb": "^3.490.0",
     "@aws-sdk/s3-request-presigner": "^3.490.0",
+    "jsonwebtoken": "^9.0.3",
+    "jwks-rsa": "^3.2.2",
     "ulid": "^2.3.0"
   },
   "devDependencies": {
     "@types/archiver": "^6.0.0",
+    "@types/jsonwebtoken": "^9.0.10",
     "archiver": "^6.0.0",
     "esbuild": "^0.19.0"
   }

--- a/backend/src/handlers/authorize.ts
+++ b/backend/src/handlers/authorize.ts
@@ -1,0 +1,144 @@
+import {
+  APIGatewayTokenAuthorizerEvent,
+  APIGatewayAuthorizerResult,
+  PolicyDocument,
+  Statement,
+} from 'aws-lambda';
+import jwt from 'jsonwebtoken';
+import jwksClient from 'jwks-rsa';
+
+const AUTH0_DOMAIN = process.env.AUTH0_DOMAIN;
+const AUTH0_AUDIENCE = process.env.AUTH0_AUDIENCE;
+const ROLES_NAMESPACE = 'https://lotg-exams.com/roles';
+
+interface DecodedToken {
+  iss: string;
+  sub: string;
+  aud: string | string[];
+  exp: number;
+  iat: number;
+  [key: string]: unknown;
+}
+
+const client = jwksClient({
+  jwksUri: `https://${AUTH0_DOMAIN}/.well-known/jwks.json`,
+  cache: true,
+  cacheMaxAge: 600000, // 10 minutes
+});
+
+function getSigningKey(kid: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    client.getSigningKey(kid, (err, key) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      const signingKey = key?.getPublicKey();
+      if (!signingKey) {
+        reject(new Error('Unable to get signing key'));
+        return;
+      }
+      resolve(signingKey);
+    });
+  });
+}
+
+function generatePolicy(
+  principalId: string,
+  effect: 'Allow' | 'Deny',
+  resource: string,
+  context?: Record<string, string | number | boolean>
+): APIGatewayAuthorizerResult {
+  const statement: Statement = {
+    Action: 'execute-api:Invoke',
+    Effect: effect,
+    Resource: resource,
+  };
+
+  const policyDocument: PolicyDocument = {
+    Version: '2012-10-17',
+    Statement: [statement],
+  };
+
+  const authResponse: APIGatewayAuthorizerResult = {
+    principalId,
+    policyDocument,
+  };
+
+  if (context) {
+    authResponse.context = context;
+  }
+
+  return authResponse;
+}
+
+export async function handler(
+  event: APIGatewayTokenAuthorizerEvent
+): Promise<APIGatewayAuthorizerResult> {
+  console.log('Authorizer invoked');
+
+  if (!AUTH0_DOMAIN || !AUTH0_AUDIENCE) {
+    console.error('Missing AUTH0_DOMAIN or AUTH0_AUDIENCE environment variables');
+    throw new Error('Unauthorized');
+  }
+
+  const token = event.authorizationToken?.replace('Bearer ', '');
+
+  if (!token) {
+    console.error('No token provided');
+    throw new Error('Unauthorized');
+  }
+
+  try {
+    // Decode token header to get kid
+    const decoded = jwt.decode(token, { complete: true });
+    if (!decoded || typeof decoded === 'string' || !decoded.header.kid) {
+      console.error('Invalid token format');
+      throw new Error('Unauthorized');
+    }
+
+    // Get signing key from Auth0
+    const signingKey = await getSigningKey(decoded.header.kid);
+
+    // Verify token
+    const verified = jwt.verify(token, signingKey, {
+      audience: AUTH0_AUDIENCE,
+      issuer: `https://${AUTH0_DOMAIN}/`,
+      algorithms: ['RS256'],
+    }) as DecodedToken;
+
+    // Extract roles from token
+    const roles = (verified[ROLES_NAMESPACE] as string[]) || [];
+    const isAdmin = roles.includes('admin');
+
+    console.log(`Token verified for user: ${verified.sub}, isAdmin: ${isAdmin}`);
+
+    // For admin routes, require admin role
+    // The methodArn format: arn:aws:execute-api:region:account:api-id/stage/method/resource
+    const methodArn = event.methodArn;
+    const isAdminRoute = methodArn.includes('/admin/');
+
+    if (isAdminRoute && !isAdmin) {
+      console.log('User attempted to access admin route without admin role');
+      return generatePolicy(verified.sub, 'Deny', event.methodArn);
+    }
+
+    // Allow access - use wildcard for resource to enable caching across endpoints
+    const arnParts = event.methodArn.split(':');
+    const apiGatewayArn = arnParts[5].split('/');
+    const region = arnParts[3];
+    const accountId = arnParts[4];
+    const apiId = apiGatewayArn[0];
+    const stage = apiGatewayArn[1];
+    const wildcardArn = `arn:aws:execute-api:${region}:${accountId}:${apiId}/${stage}/*`;
+
+    return generatePolicy(verified.sub, 'Allow', wildcardArn, {
+      userId: verified.sub,
+      isAdmin: isAdmin,
+      roles: roles.join(','),
+    });
+  } catch (error) {
+    console.error('Token verification failed:', error);
+    throw new Error('Unauthorized');
+  }
+}

--- a/frontend/src/hooks/useAccessToken.ts
+++ b/frontend/src/hooks/useAccessToken.ts
@@ -1,0 +1,38 @@
+import { useAuth0 } from '@auth0/auth0-react';
+import { useCallback, useState, useEffect } from 'react';
+
+export function useAccessToken() {
+  const { getAccessTokenSilently, isAuthenticated } = useAuth0();
+  const [token, setToken] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    async function fetchToken() {
+      if (!isAuthenticated) {
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const accessToken = await getAccessTokenSilently();
+        setToken(accessToken);
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error('Failed to get token'));
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchToken();
+  }, [getAccessTokenSilently, isAuthenticated]);
+
+  const getToken = useCallback(async () => {
+    if (!isAuthenticated) {
+      throw new Error('Not authenticated');
+    }
+    return getAccessTokenSilently();
+  }, [getAccessTokenSilently, isAuthenticated]);
+
+  return { token, loading, error, getToken };
+}

--- a/frontend/src/pages/admin/CreateQuiz.tsx
+++ b/frontend/src/pages/admin/CreateQuiz.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { createManualJob } from '../../api/client';
+import { useAccessToken } from '../../hooks/useAccessToken';
 
 const CATEGORIES = [
   'Laws of the Game',
@@ -13,6 +14,7 @@ const CATEGORIES = [
 
 export default function CreateQuiz() {
   const navigate = useNavigate();
+  const { getToken } = useAccessToken();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [category, setCategory] = useState('Laws of the Game');
@@ -31,11 +33,15 @@ export default function CreateQuiz() {
     setError(null);
 
     try {
-      const response = await createManualJob({
-        title: title.trim(),
-        description: description.trim() || undefined,
-        category,
-      });
+      const token = await getToken();
+      const response = await createManualJob(
+        {
+          title: title.trim(),
+          description: description.trim() || undefined,
+          category,
+        },
+        token
+      );
 
       // Navigate to the job detail page to add questions
       navigate(`/admin/jobs/${response.jobId}`);
@@ -49,16 +55,11 @@ export default function CreateQuiz() {
   return (
     <div>
       <div className="mb-8">
-        <Link
-          to="/admin"
-          className="text-sm text-gray-500 hover:text-gray-700 mb-2 inline-block"
-        >
+        <Link to="/admin" className="text-sm text-gray-500 hover:text-gray-700 mb-2 inline-block">
           ← Back to Dashboard
         </Link>
         <h1 className="text-2xl font-bold text-gray-900">Create Manual Quiz</h1>
-        <p className="text-gray-600">
-          Create a new quiz and add questions manually
-        </p>
+        <p className="text-gray-600">Create a new quiz and add questions manually</p>
       </div>
 
       <div className="bg-white rounded-lg shadow p-6 max-w-2xl">
@@ -70,10 +71,7 @@ export default function CreateQuiz() {
           )}
 
           <div>
-            <label
-              htmlFor="title"
-              className="block text-sm font-medium text-gray-700 mb-1"
-            >
+            <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-1">
               Quiz Title *
             </label>
             <input
@@ -88,10 +86,7 @@ export default function CreateQuiz() {
           </div>
 
           <div>
-            <label
-              htmlFor="description"
-              className="block text-sm font-medium text-gray-700 mb-1"
-            >
+            <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-1">
               Description
             </label>
             <textarea
@@ -106,10 +101,7 @@ export default function CreateQuiz() {
           </div>
 
           <div>
-            <label
-              htmlFor="category"
-              className="block text-sm font-medium text-gray-700 mb-1"
-            >
+            <label htmlFor="category" className="block text-sm font-medium text-gray-700 mb-1">
               Category
             </label>
             <select
@@ -128,11 +120,7 @@ export default function CreateQuiz() {
           </div>
 
           <div className="flex gap-4">
-            <button
-              type="submit"
-              disabled={loading}
-              className="btn-primary disabled:opacity-50"
-            >
+            <button type="submit" disabled={loading} className="btn-primary disabled:opacity-50">
               {loading ? 'Creating...' : 'Create Quiz'}
             </button>
             <Link to="/admin" className="btn-secondary">

--- a/frontend/src/pages/admin/Dashboard.tsx
+++ b/frontend/src/pages/admin/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { getExtractionJobs, getQuestionBank } from '../../api/client';
+import { useAccessToken } from '../../hooks/useAccessToken';
 import type { ExtractionJob, BankQuestion } from '../../types';
 
 interface Stats {
@@ -17,14 +18,16 @@ export default function AdminDashboard() {
   const [recentJobs, setRecentJobs] = useState<ExtractionJob[]>([]);
   const [pendingQuestions, setPendingQuestions] = useState<BankQuestion[]>([]);
   const [loading, setLoading] = useState(true);
+  const { getToken } = useAccessToken();
 
   useEffect(() => {
     async function loadData() {
       try {
+        const token = await getToken();
         const [jobsRes, questionsRes, pendingRes] = await Promise.all([
-          getExtractionJobs(),
-          getQuestionBank({ limit: 200 }),
-          getQuestionBank({ status: 'pending_review', limit: 5 }),
+          getExtractionJobs(token),
+          getQuestionBank(token, { limit: 200 }),
+          getQuestionBank(token, { status: 'pending_review', limit: 5 }),
         ]);
 
         const questions = questionsRes.questions;
@@ -47,7 +50,7 @@ export default function AdminDashboard() {
     }
 
     loadData();
-  }, []);
+  }, [getToken]);
 
   if (loading) {
     return (
@@ -71,9 +74,7 @@ export default function AdminDashboard() {
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <div className="bg-white rounded-lg shadow p-6">
           <div className="text-sm font-medium text-gray-500">Total Questions</div>
-          <div className="mt-1 text-3xl font-bold text-gray-900">
-            {stats?.totalQuestions || 0}
-          </div>
+          <div className="mt-1 text-3xl font-bold text-gray-900">{stats?.totalQuestions || 0}</div>
         </div>
         <div className="bg-white rounded-lg shadow p-6">
           <div className="text-sm font-medium text-gray-500">Approved</div>
@@ -100,10 +101,7 @@ export default function AdminDashboard() {
         <div className="bg-white rounded-lg shadow">
           <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
             <h2 className="text-lg font-semibold text-gray-900">Recent Jobs</h2>
-            <Link
-              to="/admin/jobs"
-              className="text-sm text-primary-600 hover:text-primary-700"
-            >
+            <Link to="/admin/jobs" className="text-sm text-primary-600 hover:text-primary-700">
               View all
             </Link>
           </div>
@@ -141,24 +139,17 @@ export default function AdminDashboard() {
         <div className="bg-white rounded-lg shadow">
           <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
             <h2 className="text-lg font-semibold text-gray-900">Pending Review</h2>
-            <Link
-              to="/admin/review"
-              className="text-sm text-primary-600 hover:text-primary-700"
-            >
+            <Link to="/admin/review" className="text-sm text-primary-600 hover:text-primary-700">
               Review all
             </Link>
           </div>
           <div className="divide-y divide-gray-200">
             {pendingQuestions.length === 0 ? (
-              <div className="px-6 py-8 text-center text-gray-500">
-                No questions pending review
-              </div>
+              <div className="px-6 py-8 text-center text-gray-500">No questions pending review</div>
             ) : (
               pendingQuestions.map((question) => (
                 <div key={question.questionId} className="px-6 py-4">
-                  <div className="text-sm text-gray-900 line-clamp-2">
-                    {question.text}
-                  </div>
+                  <div className="text-sm text-gray-900 line-clamp-2">{question.text}</div>
                   <div className="mt-1 flex items-center gap-2">
                     <span className="text-xs text-gray-500">{question.law}</span>
                     <span className="text-xs text-gray-400">|</span>
@@ -175,10 +166,7 @@ export default function AdminDashboard() {
       <div className="bg-white rounded-lg shadow p-6">
         <h2 className="text-lg font-semibold text-gray-900 mb-4">Quick Actions</h2>
         <div className="flex flex-wrap gap-4">
-          <Link
-            to="/admin/upload"
-            className="btn-primary"
-          >
+          <Link to="/admin/upload" className="btn-primary">
             Upload New PDF
           </Link>
           <Link
@@ -187,16 +175,10 @@ export default function AdminDashboard() {
           >
             Create Manual Quiz
           </Link>
-          <Link
-            to="/admin/review"
-            className="btn-secondary"
-          >
+          <Link to="/admin/review" className="btn-secondary">
             Review Questions ({stats?.pendingQuestions || 0})
           </Link>
-          <Link
-            to="/admin/questions"
-            className="btn-secondary"
-          >
+          <Link to="/admin/questions" className="btn-secondary">
             Browse Question Bank
           </Link>
         </div>

--- a/frontend/src/pages/admin/Jobs.tsx
+++ b/frontend/src/pages/admin/Jobs.tsx
@@ -1,17 +1,20 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { getExtractionJobs } from '../../api/client';
+import { useAccessToken } from '../../hooks/useAccessToken';
 import type { ExtractionJob } from '../../types';
 
 export default function AdminJobs() {
   const [jobs, setJobs] = useState<ExtractionJob[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { getToken } = useAccessToken();
 
   useEffect(() => {
     async function loadJobs() {
       try {
-        const res = await getExtractionJobs();
+        const token = await getToken();
+        const res = await getExtractionJobs(token);
         setJobs(res.jobs);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load jobs');
@@ -21,7 +24,7 @@ export default function AdminJobs() {
     }
 
     loadJobs();
-  }, []);
+  }, [getToken]);
 
   if (loading) {
     return (
@@ -103,18 +106,14 @@ export default function AdminJobs() {
               {jobs.map((job) => (
                 <tr key={job.jobId} className="hover:bg-gray-50">
                   <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="text-sm font-medium text-gray-900">
-                      {job.fileName}
-                    </div>
+                    <div className="text-sm font-medium text-gray-900">{job.fileName}</div>
                     <div className="text-xs text-gray-500">{job.jobId}</div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
                     <StatusBadge status={job.status} />
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="text-sm text-gray-900">
-                      {job.totalQuestions} total
-                    </div>
+                    <div className="text-sm text-gray-900">{job.totalQuestions} total</div>
                     {job.duplicateCount > 0 && (
                       <div className="text-xs text-gray-500">
                         {job.duplicateCount} duplicates skipped
@@ -123,19 +122,13 @@ export default function AdminJobs() {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
                     <div className="flex items-center gap-2 text-xs">
-                      <span className="text-green-600">
-                        {job.approvedCount} approved
-                      </span>
+                      <span className="text-green-600">{job.approvedCount} approved</span>
                       <span className="text-gray-400">|</span>
-                      <span className="text-yellow-600">
-                        {job.pendingCount} pending
-                      </span>
+                      <span className="text-yellow-600">{job.pendingCount} pending</span>
                       {job.rejectedCount > 0 && (
                         <>
                           <span className="text-gray-400">|</span>
-                          <span className="text-red-600">
-                            {job.rejectedCount} rejected
-                          </span>
+                          <span className="text-red-600">{job.rejectedCount} rejected</span>
                         </>
                       )}
                     </div>

--- a/frontend/src/pages/admin/QuestionBank.tsx
+++ b/frontend/src/pages/admin/QuestionBank.tsx
@@ -1,12 +1,26 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { getQuestionBank } from '../../api/client';
+import { useAccessToken } from '../../hooks/useAccessToken';
 import type { BankQuestion, Law, QuestionStatus } from '../../types';
 
 const LAWS: Law[] = [
-  'Law 1', 'Law 2', 'Law 3', 'Law 4', 'Law 5',
-  'Law 6', 'Law 7', 'Law 8', 'Law 9', 'Law 10',
-  'Law 11', 'Law 12', 'Law 13', 'Law 14', 'Law 15',
-  'Law 16', 'Law 17',
+  'Law 1',
+  'Law 2',
+  'Law 3',
+  'Law 4',
+  'Law 5',
+  'Law 6',
+  'Law 7',
+  'Law 8',
+  'Law 9',
+  'Law 10',
+  'Law 11',
+  'Law 12',
+  'Law 13',
+  'Law 14',
+  'Law 15',
+  'Law 16',
+  'Law 17',
 ];
 
 const STATUSES: { value: QuestionStatus | ''; label: string }[] = [
@@ -23,15 +37,13 @@ export default function AdminQuestionBank() {
   const [lawFilter, setLawFilter] = useState<Law | ''>('');
   const [statusFilter, setStatusFilter] = useState<QuestionStatus | ''>('');
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const { getToken } = useAccessToken();
 
-  useEffect(() => {
-    loadQuestions();
-  }, [lawFilter, statusFilter]);
-
-  async function loadQuestions() {
+  const loadQuestions = useCallback(async () => {
     setLoading(true);
     try {
-      const res = await getQuestionBank({
+      const token = await getToken();
+      const res = await getQuestionBank(token, {
         law: lawFilter || undefined,
         status: statusFilter || undefined,
         limit: 100,
@@ -42,7 +54,11 @@ export default function AdminQuestionBank() {
     } finally {
       setLoading(false);
     }
-  }
+  }, [getToken, lawFilter, statusFilter]);
+
+  useEffect(() => {
+    loadQuestions();
+  }, [loadQuestions]);
 
   const toggleExpand = (questionId: string) => {
     setExpandedId((prev) => (prev === questionId ? null : questionId));
@@ -58,18 +74,14 @@ export default function AdminQuestionBank() {
     <div>
       <div className="mb-8">
         <h1 className="text-2xl font-bold text-gray-900">Question Bank</h1>
-        <p className="text-gray-600">
-          Browse and filter all extracted questions
-        </p>
+        <p className="text-gray-600">Browse and filter all extracted questions</p>
       </div>
 
       {/* Filters */}
       <div className="bg-white rounded-lg shadow p-4 mb-6">
         <div className="flex flex-wrap items-center gap-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Filter by Law
-            </label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Filter by Law</label>
             <select
               value={lawFilter}
               onChange={(e) => setLawFilter(e.target.value as Law | '')}
@@ -84,9 +96,7 @@ export default function AdminQuestionBank() {
             </select>
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Filter by Status
-            </label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Filter by Status</label>
             <select
               value={statusFilter}
               onChange={(e) => setStatusFilter(e.target.value as QuestionStatus | '')}
@@ -147,9 +157,7 @@ export default function AdminQuestionBank() {
       ) : questions.length === 0 ? (
         <div className="bg-white rounded-lg shadow p-12 text-center">
           <p className="text-lg text-gray-600">No questions found</p>
-          <p className="text-sm text-gray-500 mt-2">
-            Try adjusting your filters
-          </p>
+          <p className="text-sm text-gray-500 mt-2">Try adjusting your filters</p>
         </div>
       ) : (
         <div className="bg-white rounded-lg shadow overflow-hidden">
@@ -198,10 +206,7 @@ function QuestionRow({
 }) {
   return (
     <>
-      <tr
-        className="hover:bg-gray-50 cursor-pointer"
-        onClick={onToggle}
-      >
+      <tr className="hover:bg-gray-50 cursor-pointer" onClick={onToggle}>
         <td className="px-6 py-4">
           <p className="text-sm text-gray-900 line-clamp-2">{question.text}</p>
         </td>
@@ -231,9 +236,7 @@ function QuestionRow({
                         : 'bg-white border border-gray-200 text-gray-700'
                     }`}
                   >
-                    <span className="font-medium mr-2">
-                      {String.fromCharCode(65 + index)}.
-                    </span>
+                    <span className="font-medium mr-2">{String.fromCharCode(65 + index)}.</span>
                     {option}
                     {index === question.correctAnswer && (
                       <span className="ml-2 text-green-600 font-medium">✓</span>
@@ -243,8 +246,7 @@ function QuestionRow({
               </div>
               {question.explanation && (
                 <div className="p-3 bg-blue-50 rounded text-sm text-blue-800">
-                  <span className="font-medium">Explanation:</span>{' '}
-                  {question.explanation}
+                  <span className="font-medium">Explanation:</span> {question.explanation}
                 </div>
               )}
               <div className="flex items-center gap-4 text-xs text-gray-500">

--- a/frontend/src/pages/admin/Upload.tsx
+++ b/frontend/src/pages/admin/Upload.tsx
@@ -2,11 +2,13 @@ import { useState, useCallback } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { useNavigate } from 'react-router-dom';
 import { getPresignedUrl, uploadPdfToS3 } from '../../api/client';
+import { useAccessToken } from '../../hooks/useAccessToken';
 
 type UploadState = 'idle' | 'getting-url' | 'uploading' | 'processing' | 'complete' | 'error';
 
 export default function AdminUpload() {
   const navigate = useNavigate();
+  const { getToken } = useAccessToken();
   const [file, setFile] = useState<File | null>(null);
   const [state, setState] = useState<UploadState>('idle');
   const [progress, setProgress] = useState(0);
@@ -39,7 +41,8 @@ export default function AdminUpload() {
       setState('getting-url');
 
       // Get presigned URL
-      const { uploadUrl, jobId: newJobId } = await getPresignedUrl(file.name);
+      const token = await getToken();
+      const { uploadUrl, jobId: newJobId } = await getPresignedUrl(file.name, token);
       setJobId(newJobId);
 
       setState('uploading');
@@ -76,9 +79,7 @@ export default function AdminUpload() {
     <div className="max-w-2xl mx-auto">
       <div className="mb-8">
         <h1 className="text-2xl font-bold text-gray-900">Upload PDF</h1>
-        <p className="text-gray-600">
-          Upload an FAI LOTG exam PDF to extract quiz questions
-        </p>
+        <p className="text-gray-600">Upload an FAI LOTG exam PDF to extract quiz questions</p>
       </div>
 
       <div className="bg-white rounded-lg shadow p-8">
@@ -90,22 +91,30 @@ export default function AdminUpload() {
                 isDragActive
                   ? 'border-primary-500 bg-primary-50'
                   : file
-                  ? 'border-green-500 bg-green-50'
-                  : 'border-gray-300 hover:border-gray-400'
+                    ? 'border-green-500 bg-green-50'
+                    : 'border-gray-300 hover:border-gray-400'
               }`}
             >
               <input {...getInputProps()} />
               {file ? (
                 <div>
                   <div className="text-4xl mb-4">
-                    <svg className="w-12 h-12 mx-auto text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                    <svg
+                      className="w-12 h-12 mx-auto text-green-500"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                      />
                     </svg>
                   </div>
                   <p className="text-lg font-medium text-gray-900">{file.name}</p>
-                  <p className="text-sm text-gray-500">
-                    {(file.size / 1024 / 1024).toFixed(2)} MB
-                  </p>
+                  <p className="text-sm text-gray-500">{(file.size / 1024 / 1024).toFixed(2)} MB</p>
                   <button
                     type="button"
                     onClick={(e) => {
@@ -120,8 +129,18 @@ export default function AdminUpload() {
               ) : (
                 <div>
                   <div className="text-4xl mb-4">
-                    <svg className="w-12 h-12 mx-auto text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+                    <svg
+                      className="w-12 h-12 mx-auto text-gray-400"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
+                      />
                     </svg>
                   </div>
                   {isDragActive ? (
@@ -131,9 +150,7 @@ export default function AdminUpload() {
                       <p className="text-lg text-gray-600">
                         Drag and drop a PDF here, or click to select
                       </p>
-                      <p className="text-sm text-gray-500 mt-2">
-                        Only PDF files are accepted
-                      </p>
+                      <p className="text-sm text-gray-500 mt-2">Only PDF files are accepted</p>
                     </>
                   )}
                 </div>
@@ -185,8 +202,18 @@ export default function AdminUpload() {
         {state === 'complete' && (
           <div className="text-center py-8">
             <div className="text-4xl mb-4">
-              <svg className="w-12 h-12 mx-auto text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              <svg
+                className="w-12 h-12 mx-auto text-green-500"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M5 13l4 4L19 7"
+                />
               </svg>
             </div>
             <p className="text-lg font-medium text-gray-900">Upload Complete!</p>
@@ -197,8 +224,18 @@ export default function AdminUpload() {
         {state === 'error' && (
           <div className="text-center py-8">
             <div className="text-4xl mb-4">
-              <svg className="w-12 h-12 mx-auto text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              <svg
+                className="w-12 h-12 mx-auto text-red-500"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
               </svg>
             </div>
             <p className="text-lg font-medium text-gray-900">Upload Failed</p>


### PR DESCRIPTION
## Summary
- Adds Lambda authorizer to validate Auth0 JWT tokens on all admin API endpoints
- Updates frontend to include access tokens in API requests to protected routes
- Creates `useAccessToken` hook for consistent token management across admin pages

## Changes
**Backend:**
- New `authorize.ts` Lambda handler validates JWTs using Auth0 JWKS
- Validates issuer, audience, expiration, and admin role claims

**Infrastructure:**
- API Gateway authorizer resource with 300s token caching
- All 9 admin routes now use CUSTOM authorization
- New `auth0_domain` and `auth0_audience` variables

**Frontend:**
- `useAccessToken` hook wraps `getAccessTokenSilently()`
- All admin pages updated to pass tokens to API calls
- `fetchAPI` function accepts optional token parameter

## Test plan
- [ ] Deploy to staging and verify admin endpoints return 401 without token
- [ ] Verify admin endpoints work with valid Auth0 token
- [ ] Verify non-admin users cannot access admin endpoints
- [ ] Verify public endpoints (quiz, questions) still work without auth

## Required Setup
Add these secrets to GitHub repository:
- `AUTH0_DOMAIN` - Auth0 tenant domain
- `AUTH0_AUDIENCE` - Auth0 API audience identifier

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)