### PR TITLE
chore(infra): trigger fresh terraform plan

### DIFF
--- a/.infra/main.tf
+++ b/.infra/main.tf
@@ -1,3 +1,4 @@
+# AWS Provider configuration
 provider "aws" {
   region = var.aws_region
 


### PR DESCRIPTION
## Summary
- Adds a comment to `.infra/main.tf` to trigger a fresh terraform plan/apply

This is needed because the previous plan became stale after manually deleting CloudWatch log groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)