### PR TITLE
fix(quiz): shorten confetti celebration on high scores

### DIFF
--- a/frontend/src/pages/QuizResults.tsx
+++ b/frontend/src/pages/QuizResults.tsx
@@ -6,24 +6,24 @@ import type { Answer, SubmitAnswersResponse } from '../types';
 
 function triggerConfetti(percentage: number) {
   if (percentage >= 90) {
-    // Big celebration for 90%+
-    const duration = 3000;
+    const duration = 1200;
     const end = Date.now() + duration;
+    const colors = ['#10b981', '#059669', '#047857', '#34d399'];
 
     const frame = () => {
       confetti({
-        particleCount: 4,
+        particleCount: 3,
         angle: 60,
         spread: 55,
         origin: { x: 0 },
-        colors: ['#10b981', '#059669', '#047857', '#34d399'],
+        colors,
       });
       confetti({
-        particleCount: 4,
+        particleCount: 3,
         angle: 120,
         spread: 55,
         origin: { x: 1 },
-        colors: ['#10b981', '#059669', '#047857', '#34d399'],
+        colors,
       });
 
       if (Date.now() < end) {


### PR DESCRIPTION
## Summary

The 90%+ score confetti loop ran for 3 seconds with 4 particles per frame, which felt overwhelming on a 100% result. Cut the duration to 1.2s and dropped per-frame particle count to 3. Same colors and dual-side launch, just a snappier finish.

## Test plan

- [x] Submit a quiz and score 90% or higher; confirm confetti is noticeably shorter and lighter
- [x] Submit a quiz scoring 70-89%; confirm the medium burst is unchanged
- [x] Submit a quiz below 70%; confirm no confetti

https://claude.ai/code/session_012ovSD71NbDWLfcCwfsdtE2

---
_Generated by [Claude Code](https://claude.ai/code/session_012ovSD71NbDWLfcCwfsdtE2)_