### PR TITLE
ci(deploy): bump Terraform to 1.10.5

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   AWS_REGION: us-east-1
   AWS_ROLE_ARN: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/lotg-exams-github-actions
-  TF_VERSION: 1.6.0
+  TF_VERSION: 1.10.5
   NODE_VERSION: 20
   TF_VAR_auth0_domain: ${{ secrets.AUTH0_DOMAIN }}
   TF_VAR_auth0_audience: ${{ secrets.AUTH0_AUDIENCE }}


### PR DESCRIPTION
## Summary

`terraform init` is failing in CI with:

```
Error while installing hashicorp/aws v5.100.0: error checking signature:
openpgp: key expired
```

This is a known upstream HashiCorp issue: the old PGP key used to sign certain AWS provider releases has rotated. Terraform versions older than 1.10 fail signature verification when fetching the affected provider versions from the registry. Bumping to 1.10.5 picks up the updated keys and resolves the failure.

The bump is compatible with the existing `required_version = "~> 1.6"` in `.infra/versions.tf`, so no Terraform code change is required.

## Test plan

- [ ] Push triggers the `terraform-plan` job and `Terraform Init` succeeds
- [ ] Plan completes (with or without changes) without provider download errors

## Follow-ups (not in this PR)

- Commit a `.terraform.lock.hcl` so CI installs deterministic provider versions
- Pin `aws` to a specific minor in `versions.tf` to avoid drifting onto problematic provider versions in the future

https://claude.ai/code/session_012ovSD71NbDWLfcCwfsdtE2

---
_Generated by [Claude Code](https://claude.ai/code/session_012ovSD71NbDWLfcCwfsdtE2)_