### PR TITLE
feat(quiz): time limits, law filter, and per-quiz question count

### DIFF
--- a/backend/src/handlers/createManualJob.ts
+++ b/backend/src/handlers/createManualJob.ts
@@ -1,12 +1,21 @@
 import { ulid } from 'ulid';
-import type { APIGatewayProxyEvent, APIGatewayProxyResult, ExtractionJobItem } from '../lib/types.js';
+import type { APIGatewayProxyEvent, APIGatewayProxyResult, ExtractionJobItem, Law } from '../lib/types.js';
 import { createExtractionJob } from '../lib/dynamodb.js';
 import { successResponse, errorResponse } from '../lib/response.js';
+
+const VALID_LAWS = new Set<Law>([
+  'Law 1', 'Law 2', 'Law 3', 'Law 4', 'Law 5', 'Law 6', 'Law 7', 'Law 8',
+  'Law 9', 'Law 10', 'Law 11', 'Law 12', 'Law 13', 'Law 14', 'Law 15',
+  'Law 16', 'Law 17',
+]);
 
 interface CreateManualJobRequest {
   title: string;
   description?: string;
   category?: string;
+  timeLimitMinutes?: number;
+  lawFilter?: Law;
+  questionsPerAttempt?: number;
 }
 
 /**
@@ -29,6 +38,32 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
   if (!request.title || request.title.trim() === '') {
     return errorResponse('title is required', 400);
+  }
+
+  if (request.timeLimitMinutes !== undefined) {
+    if (
+      typeof request.timeLimitMinutes !== 'number' ||
+      !Number.isFinite(request.timeLimitMinutes) ||
+      request.timeLimitMinutes < 1 ||
+      request.timeLimitMinutes > 240
+    ) {
+      return errorResponse('timeLimitMinutes must be a number between 1 and 240', 400);
+    }
+  }
+
+  if (request.questionsPerAttempt !== undefined) {
+    if (
+      typeof request.questionsPerAttempt !== 'number' ||
+      !Number.isInteger(request.questionsPerAttempt) ||
+      request.questionsPerAttempt < 1 ||
+      request.questionsPerAttempt > 50
+    ) {
+      return errorResponse('questionsPerAttempt must be an integer between 1 and 50', 400);
+    }
+  }
+
+  if (request.lawFilter !== undefined && !VALID_LAWS.has(request.lawFilter)) {
+    return errorResponse('lawFilter must be a valid Law (e.g. "Law 12")', 400);
   }
 
   try {
@@ -55,6 +90,9 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
       source: 'manual_entry',
       description: request.description?.trim() || '',
       category: request.category?.trim() || 'Laws of the Game',
+      ...(request.timeLimitMinutes !== undefined && { timeLimitMinutes: request.timeLimitMinutes }),
+      ...(request.lawFilter !== undefined && { lawFilter: request.lawFilter }),
+      ...(request.questionsPerAttempt !== undefined && { questionsPerAttempt: request.questionsPerAttempt }),
     };
 
     await createExtractionJob(job);

--- a/backend/src/handlers/getQuestions.ts
+++ b/backend/src/handlers/getQuestions.ts
@@ -11,14 +11,17 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
   const quizId = event.pathParameters?.id;
   const limitParam = event.queryStringParameters?.limit;
-  const limit = limitParam ? parseInt(limitParam, 10) : 10;
 
   if (!quizId) {
     return errorResponse('Missing quiz ID', 400);
   }
 
-  if (isNaN(limit) || limit < 1 || limit > 50) {
-    return errorResponse('Limit must be between 1 and 50', 400);
+  let limit: number | undefined;
+  if (limitParam) {
+    limit = parseInt(limitParam, 10);
+    if (isNaN(limit) || limit < 1 || limit > 50) {
+      return errorResponse('Limit must be between 1 and 50', 400);
+    }
   }
 
   try {
@@ -29,15 +32,18 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
       return errorResponse('Quiz not found', 404);
     }
 
-    // Get approved questions for this job
-    const questions = await getApprovedQuestionsByJobId(quizId);
+    // Get approved questions for this job, optionally narrowed by the quiz's law filter
+    const allQuestions = await getApprovedQuestionsByJobId(quizId);
+    const questions = job.lawFilter
+      ? allQuestions.filter((q) => q.law === job.lawFilter)
+      : allQuestions;
 
     if (questions.length === 0) {
       return errorResponse('No questions found for this quiz', 404);
     }
 
-    // Shuffle and limit questions
-    const shuffled = shuffleArray(questions).slice(0, limit);
+    const effectiveLimit = limit ?? job.questionsPerAttempt ?? 10;
+    const shuffled = shuffleArray(questions).slice(0, effectiveLimit);
 
     // Transform to response format (without correct answers)
     const response: Question[] = shuffled.map((q) => ({

--- a/backend/src/handlers/getQuiz.ts
+++ b/backend/src/handlers/getQuiz.ts
@@ -42,11 +42,14 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
     const detail: QuizDetail = {
       quizId: job.jobId,
       title: formatTitle(job.fileName),
-      description: `Questions extracted from ${job.fileName}`,
-      category: 'Laws of the Game',
+      description: job.description?.trim() || `Questions extracted from ${job.fileName}`,
+      category: job.category || 'Laws of the Game',
       questionCount: job.approvedCount,
       createdAt: job.createdAt,
       updatedAt: job.updatedAt,
+      ...(job.timeLimitMinutes !== undefined && { timeLimitMinutes: job.timeLimitMinutes }),
+      ...(job.lawFilter !== undefined && { lawFilter: job.lawFilter }),
+      ...(job.questionsPerAttempt !== undefined && { questionsPerAttempt: job.questionsPerAttempt }),
     };
 
     return successResponse(detail);

--- a/backend/src/handlers/getQuizzes.ts
+++ b/backend/src/handlers/getQuizzes.ts
@@ -27,9 +27,12 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
     const summaries: QuizSummary[] = jobs.map((job) => ({
       quizId: job.jobId,
       title: formatTitle(job.fileName),
-      description: `Questions extracted from ${job.fileName}`,
-      category: 'Laws of the Game',
+      description: job.description?.trim() || `Questions extracted from ${job.fileName}`,
+      category: job.category || 'Laws of the Game',
       questionCount: job.approvedCount,
+      ...(job.timeLimitMinutes !== undefined && { timeLimitMinutes: job.timeLimitMinutes }),
+      ...(job.lawFilter !== undefined && { lawFilter: job.lawFilter }),
+      ...(job.questionsPerAttempt !== undefined && { questionsPerAttempt: job.questionsPerAttempt }),
     }));
 
     return successResponse(summaries);

--- a/backend/src/lib/types.ts
+++ b/backend/src/lib/types.ts
@@ -92,6 +92,10 @@ export interface ExtractionJobItem {
   source?: JobSource; // 'pdf_extraction' | 'manual_entry'
   description?: string; // Quiz description (for manual jobs)
   category?: string; // Quiz category (default: 'Laws of the Game')
+  // Quiz configuration (issue #14)
+  timeLimitMinutes?: number;
+  lawFilter?: Law;
+  questionsPerAttempt?: number;
 }
 
 // API response types
@@ -101,6 +105,9 @@ export interface QuizSummary {
   description: string;
   category: string;
   questionCount: number;
+  timeLimitMinutes?: number;
+  lawFilter?: Law;
+  questionsPerAttempt?: number;
 }
 
 export interface QuizDetail extends QuizSummary {
@@ -159,6 +166,9 @@ export interface ExtractionJob {
   source?: JobSource;
   description?: string;
   category?: string;
+  timeLimitMinutes?: number;
+  lawFilter?: Law;
+  questionsPerAttempt?: number;
 }
 
 // Claude extraction types

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -53,8 +53,9 @@ export async function getQuiz(quizId: string): Promise<QuizDetail> {
   return fetchAPI<QuizDetail>(`/quizzes/${quizId}`);
 }
 
-export async function getQuestions(quizId: string, limit = 10): Promise<Question[]> {
-  return fetchAPI<Question[]>(`/quizzes/${quizId}/questions?limit=${limit}`);
+export async function getQuestions(quizId: string, limit?: number): Promise<Question[]> {
+  const query = limit !== undefined ? `?limit=${limit}` : '';
+  return fetchAPI<Question[]>(`/quizzes/${quizId}/questions${query}`);
 }
 
 export async function submitAnswers(

--- a/frontend/src/pages/QuizResults.tsx
+++ b/frontend/src/pages/QuizResults.tsx
@@ -70,6 +70,7 @@ export default function QuizResults() {
   const [error, setError] = useState<string | null>(null);
   const [durationMs, setDurationMs] = useState<number | null>(null);
   const [reviewWrongOnly, setReviewWrongOnly] = useState(false);
+  const [autoSubmitted, setAutoSubmitted] = useState(false);
 
   useEffect(() => {
     async function loadResults() {
@@ -85,6 +86,8 @@ export default function QuizResults() {
       if (Number.isFinite(startedAt) && startedAt > 0) {
         setDurationMs(Date.now() - startedAt);
       }
+
+      setAutoSubmitted(sessionStorage.getItem('quizAutoSubmitted') === 'true');
 
       try {
         const answers: Answer[] = JSON.parse(storedAnswers);
@@ -106,6 +109,7 @@ export default function QuizResults() {
     sessionStorage.removeItem('quizQuestions');
     sessionStorage.removeItem('quizAnswers');
     sessionStorage.removeItem('quizStartedAt');
+    sessionStorage.removeItem('quizAutoSubmitted');
   };
 
   const handleRetry = () => {
@@ -179,6 +183,11 @@ export default function QuizResults() {
     <div className="container mx-auto px-4 py-8 max-w-4xl">
       <div className="card mb-8 text-center">
         <h1 className="text-3xl font-bold text-gray-900 mb-4">Quiz Results</h1>
+        {autoSubmitted && (
+          <div className="bg-amber-50 border border-amber-200 text-amber-800 text-sm rounded-lg p-3 mb-4">
+            Time ran out — your quiz was submitted automatically.
+          </div>
+        )}
         <p className={`text-lg font-medium mb-4 ${message.color}`}>{message.text}</p>
         <div className="flex items-center justify-center gap-8 mb-4 flex-wrap">
           <div>
@@ -270,6 +279,9 @@ export default function QuizResults() {
                       </div>
                     );
                   })}
+                  {result.selectedOption < 0 && (
+                    <p className="text-sm font-medium text-amber-700">Not answered</p>
+                  )}
                 </div>
 
                 <div className="bg-blue-50 border-l-4 border-blue-500 p-4 rounded">

--- a/frontend/src/pages/QuizTake.tsx
+++ b/frontend/src/pages/QuizTake.tsx
@@ -1,7 +1,13 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { getQuiz, getQuestions } from '../api/client';
 import type { QuizDetail, Question, Answer } from '../types';
+
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
 
 export default function QuizTake() {
   const { quizId } = useParams<{ quizId: string }>();
@@ -13,6 +19,19 @@ export default function QuizTake() {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [secondsLeft, setSecondsLeft] = useState<number | null>(null);
+
+  const answersRef = useRef<Answer[]>([]);
+  const questionsRef = useRef<Question[]>([]);
+  const submittedRef = useRef(false);
+
+  useEffect(() => {
+    answersRef.current = answers;
+  }, [answers]);
+
+  useEffect(() => {
+    questionsRef.current = questions;
+  }, [questions]);
 
   useEffect(() => {
     async function loadQuiz() {
@@ -21,11 +40,14 @@ export default function QuizTake() {
       try {
         const [quizData, questionsData] = await Promise.all([
           getQuiz(quizId),
-          getQuestions(quizId, 10),
+          getQuestions(quizId),
         ]);
         setQuiz(quizData);
         setQuestions(questionsData);
         sessionStorage.setItem('quizStartedAt', Date.now().toString());
+        if (quizData.timeLimitMinutes && quizData.timeLimitMinutes > 0) {
+          setSecondsLeft(quizData.timeLimitMinutes * 60);
+        }
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load quiz');
       } finally {
@@ -35,6 +57,36 @@ export default function QuizTake() {
 
     loadQuiz();
   }, [quizId]);
+
+  const submit = useCallback(
+    (auto: boolean) => {
+      if (!quizId || submittedRef.current) return;
+      submittedRef.current = true;
+
+      // Pad unanswered with -1 so the backend's score divisor stays correct
+      const finalAnswers: Answer[] = questionsRef.current.map((q) => {
+        const existing = answersRef.current.find((a) => a.questionId === q.questionId);
+        return existing ?? { questionId: q.questionId, selectedOption: -1 };
+      });
+
+      sessionStorage.setItem('quizAnswers', JSON.stringify(finalAnswers));
+      sessionStorage.setItem('quizQuestions', JSON.stringify(questionsRef.current));
+      sessionStorage.setItem('quizAutoSubmitted', auto ? 'true' : 'false');
+
+      navigate(`/quiz/${quizId}/results`);
+    },
+    [quizId, navigate]
+  );
+
+  useEffect(() => {
+    if (secondsLeft === null) return;
+    if (secondsLeft <= 0) {
+      submit(true);
+      return;
+    }
+    const id = window.setTimeout(() => setSecondsLeft((s) => (s === null ? s : s - 1)), 1000);
+    return () => window.clearTimeout(id);
+  }, [secondsLeft, submit]);
 
   const currentQuestion = questions[currentIndex];
   const currentAnswer = answers.find(
@@ -68,30 +120,23 @@ export default function QuizTake() {
     setCurrentIndex((i) => (i > 0 ? i - 1 : i));
   }, []);
 
-  const handleSubmit = useCallback(() => {
-    if (!quizId) return;
-
-    sessionStorage.setItem('quizAnswers', JSON.stringify(answers));
-    sessionStorage.setItem('quizQuestions', JSON.stringify(questions));
-
-    navigate(`/quiz/${quizId}/results`);
-  }, [quizId, answers, questions, navigate]);
+  const handleSubmit = useCallback(() => submit(false), [submit]);
 
   const isLast = currentIndex === questions.length - 1;
-  const canSubmit = answers.length === questions.length && questions.length > 0;
+  const answeredCount = answers.filter((a) => a.selectedOption >= 0).length;
+  const canSubmit = answeredCount === questions.length && questions.length > 0;
+  const lowTime = secondsLeft !== null && secondsLeft <= 60;
 
   useEffect(() => {
     if (loading || error || !currentQuestion) return;
 
     const onKeyDown = (e: KeyboardEvent) => {
-      // Ignore if focus is in an editable element (defensive — none on this page today)
       const target = e.target as HTMLElement | null;
       if (target?.isContentEditable) return;
       const tag = target?.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
       if (e.metaKey || e.ctrlKey || e.altKey) return;
 
-      // Number keys 1-9 select the matching option (when present)
       if (e.key >= '1' && e.key <= '9') {
         const idx = parseInt(e.key, 10) - 1;
         if (idx < currentQuestion.options.length) {
@@ -171,16 +216,27 @@ export default function QuizTake() {
   }
 
   const progress = ((currentIndex + 1) / questions.length) * 100;
-  const answeredCount = answers.length;
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-3xl">
       <div className="mb-6">
         <div className="flex items-center justify-between mb-2">
           <h1 className="text-2xl font-bold text-gray-900">{quiz.title}</h1>
-          <span className="text-sm text-gray-600">
-            Question {currentIndex + 1} of {questions.length}
-          </span>
+          <div className="flex items-center gap-4">
+            {secondsLeft !== null && (
+              <span
+                className={`text-sm font-mono font-semibold px-3 py-1 rounded-full ${
+                  lowTime ? 'bg-red-100 text-red-700' : 'bg-gray-100 text-gray-700'
+                }`}
+                aria-label="Time remaining"
+              >
+                {formatTime(Math.max(0, secondsLeft))}
+              </span>
+            )}
+            <span className="text-sm text-gray-600">
+              Question {currentIndex + 1} of {questions.length}
+            </span>
+          </div>
         </div>
         <div className="w-full bg-gray-200 rounded-full h-2">
           <div

--- a/frontend/src/pages/admin/CreateQuiz.tsx
+++ b/frontend/src/pages/admin/CreateQuiz.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { createManualJob } from '../../api/client';
 import { useAccessToken } from '../../hooks/useAccessToken';
+import type { Law } from '../../types';
 
 const CATEGORIES = [
   'Laws of the Game',
@@ -12,12 +13,21 @@ const CATEGORIES = [
   'General Knowledge',
 ];
 
+const LAWS: Law[] = [
+  'Law 1', 'Law 2', 'Law 3', 'Law 4', 'Law 5', 'Law 6', 'Law 7', 'Law 8',
+  'Law 9', 'Law 10', 'Law 11', 'Law 12', 'Law 13', 'Law 14', 'Law 15',
+  'Law 16', 'Law 17',
+];
+
 export default function CreateQuiz() {
   const navigate = useNavigate();
   const { getToken } = useAccessToken();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [category, setCategory] = useState('Laws of the Game');
+  const [timeLimit, setTimeLimit] = useState('');
+  const [lawFilter, setLawFilter] = useState<'' | Law>('');
+  const [questionsPerAttempt, setQuestionsPerAttempt] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -27,6 +37,26 @@ export default function CreateQuiz() {
     if (!title.trim()) {
       setError('Title is required');
       return;
+    }
+
+    let timeLimitMinutes: number | undefined;
+    if (timeLimit.trim()) {
+      const parsed = Number(timeLimit);
+      if (!Number.isFinite(parsed) || parsed < 1 || parsed > 240) {
+        setError('Time limit must be between 1 and 240 minutes');
+        return;
+      }
+      timeLimitMinutes = parsed;
+    }
+
+    let questionsPerAttemptNum: number | undefined;
+    if (questionsPerAttempt.trim()) {
+      const parsed = Number(questionsPerAttempt);
+      if (!Number.isInteger(parsed) || parsed < 1 || parsed > 50) {
+        setError('Questions per attempt must be a whole number between 1 and 50');
+        return;
+      }
+      questionsPerAttemptNum = parsed;
     }
 
     setLoading(true);
@@ -39,6 +69,9 @@ export default function CreateQuiz() {
           title: title.trim(),
           description: description.trim() || undefined,
           category,
+          timeLimitMinutes,
+          lawFilter: lawFilter || undefined,
+          questionsPerAttempt: questionsPerAttemptNum,
         },
         token
       );
@@ -117,6 +150,68 @@ export default function CreateQuiz() {
                 </option>
               ))}
             </select>
+          </div>
+
+          <div className="border-t pt-6">
+            <h2 className="text-sm font-semibold text-gray-900 mb-4">
+              Quiz Configuration <span className="font-normal text-gray-500">(optional)</span>
+            </h2>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="timeLimit" className="block text-sm font-medium text-gray-700 mb-1">
+                  Time Limit (minutes)
+                </label>
+                <input
+                  type="number"
+                  id="timeLimit"
+                  min={1}
+                  max={240}
+                  value={timeLimit}
+                  onChange={(e) => setTimeLimit(e.target.value)}
+                  placeholder="No limit"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                  disabled={loading}
+                />
+              </div>
+
+              <div>
+                <label htmlFor="questionsPerAttempt" className="block text-sm font-medium text-gray-700 mb-1">
+                  Questions per Attempt
+                </label>
+                <input
+                  type="number"
+                  id="questionsPerAttempt"
+                  min={1}
+                  max={50}
+                  value={questionsPerAttempt}
+                  onChange={(e) => setQuestionsPerAttempt(e.target.value)}
+                  placeholder="Default: 10"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                  disabled={loading}
+                />
+              </div>
+
+              <div className="sm:col-span-2">
+                <label htmlFor="lawFilter" className="block text-sm font-medium text-gray-700 mb-1">
+                  Restrict to a Single Law
+                </label>
+                <select
+                  id="lawFilter"
+                  value={lawFilter}
+                  onChange={(e) => setLawFilter(e.target.value as '' | Law)}
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                  disabled={loading}
+                >
+                  <option value="">All laws</option>
+                  {LAWS.map((law) => (
+                    <option key={law} value={law}>
+                      {law}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
           </div>
 
           <div className="flex gap-4">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -4,6 +4,9 @@ export interface QuizSummary {
   description: string;
   category: string;
   questionCount: number;
+  timeLimitMinutes?: number;
+  lawFilter?: Law;
+  questionsPerAttempt?: number;
 }
 
 export interface QuizDetail extends QuizSummary {
@@ -86,6 +89,9 @@ export interface ExtractionJob {
   source?: JobSource;
   description?: string;
   category?: string;
+  timeLimitMinutes?: number;
+  lawFilter?: Law;
+  questionsPerAttempt?: number;
 }
 
 export interface PresignedUrlResponse {
@@ -147,6 +153,9 @@ export interface CreateManualJobRequest {
   title: string;
   description?: string;
   category?: string;
+  timeLimitMinutes?: number;
+  lawFilter?: Law;
+  questionsPerAttempt?: number;
 }
 
 export interface CreateManualJobResponse {


### PR DESCRIPTION
## Summary

Adds three optional quiz-configuration fields to the quiz (extraction job) schema and surfaces them through the create / take / grade flow:

- `timeLimitMinutes` — `QuizTake` shows a `MM:SS` countdown that turns red under 60s, then auto-submits on expiry. Unanswered questions are sent as `selectedOption: -1` so the score divisor stays correct
- `lawFilter` — `getQuestions` narrows the approved-question pool to a single law before sampling
- `questionsPerAttempt` — replaces the hardcoded `10` in `getQuestions` when the client doesn't pass an explicit `?limit`

Side polish while in the area:
- `getQuiz` / `getQuizzes` stop hardcoding `description` / `category` and pass through whatever `createManualJob` actually stored
- `QuizResults` shows a "Time ran out — auto-submitted" banner and renders "Not answered" instead of "Your Answer" when `selectedOption < 0`
- `CreateQuiz` has a new "Quiz Configuration (optional)" block with validated number inputs and a Law dropdown

The admin question-picker piece of #14 is intentionally **deferred** to a follow-up — letting admins pick arbitrary questions across PDF jobs implies breaking the question-to-quiz `jobId` binding (either a new `QuizQuestion` mapping item or a `questionIds[]` list on the quiz). That is a real schema change worth its own design pass and shouldn't ride along with this PR.

Refs #14

## Test plan

- [ ] Create a manual quiz with no config fields set — quizzes still serve 10 questions, no countdown, all laws
- [ ] Create one with `timeLimitMinutes=2` — countdown appears, turns red at 1:00, auto-submits at 0:00
- [ ] Submit before the timer runs out — no auto-submit banner on results
- [ ] Auto-submit with some questions unanswered — results show "Not answered" rows and the percentage divisor matches total questions, not just answered ones
- [ ] Create one with `lawFilter="Law 12"` — only Law 12 questions are served
- [ ] Create one with `questionsPerAttempt=5` — exactly 5 questions are served
- [ ] Backend rejects `timeLimitMinutes` outside 1-240, `questionsPerAttempt` outside 1-50, and `lawFilter` not in the Law enum

https://claude.ai/code/session_012ovSD71NbDWLfcCwfsdtE2

---
_Generated by [Claude Code](https://claude.ai/code/session_012ovSD71NbDWLfcCwfsdtE2)_