### PR TITLE
fix(infra): attach CORS headers to API Gateway error responses

### DIFF
--- a/.infra/modules/backend/main.tf
+++ b/.infra/modules/backend/main.tf
@@ -220,6 +220,31 @@ resource "aws_api_gateway_authorizer" "jwt" {
   authorizer_result_ttl_in_seconds = 300
 }
 
+# Gateway responses
+#
+# Without these, 4xx/5xx responses (in particular UNAUTHORIZED and ACCESS_DENIED
+# from the Lambda authorizer) come back without CORS headers. The browser then
+# rejects them with an opaque "Failed to fetch" instead of letting JS see the
+# real status. Setting CORS headers here makes auth failures surface as proper
+# HTTP errors that the frontend can display.
+locals {
+  gateway_response_cors_headers = {
+    "gatewayresponse.header.Access-Control-Allow-Origin"  = "'*'"
+    "gatewayresponse.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization'"
+    "gatewayresponse.header.Access-Control-Allow-Methods" = "'GET,POST,PUT,DELETE,OPTIONS'"
+  }
+
+  gateway_response_types = ["UNAUTHORIZED", "ACCESS_DENIED", "DEFAULT_4XX", "DEFAULT_5XX"]
+}
+
+resource "aws_api_gateway_gateway_response" "cors" {
+  for_each = toset(local.gateway_response_types)
+
+  rest_api_id         = aws_api_gateway_rest_api.this.id
+  response_type       = each.key
+  response_parameters = local.gateway_response_cors_headers
+}
+
 # IAM role for API Gateway to invoke authorizer Lambda
 resource "aws_iam_role" "api_gateway_authorizer" {
   name = "${var.project_name}-${var.environment}-apigw-auth-role"
@@ -418,6 +443,7 @@ resource "aws_api_gateway_deployment" "this" {
       aws_api_gateway_resource.admin_questions.id,
       aws_api_gateway_resource.admin_jobs_manual.id,
       aws_api_gateway_resource.admin_job_questions.id,
+      [for r in aws_api_gateway_gateway_response.cors : r.id],
     ]))
   }
 }


### PR DESCRIPTION
## Why "Failed to fetch" on /admin/jobs

When the JWT Lambda authorizer denies a request or throws (token invalid, role missing, JWKS fetch failed, etc.), API Gateway returns a 401 / 403 — but **without CORS headers**. The browser rejects that response and the `fetch()` promise rejects with `TypeError: Failed to fetch`, which is what `client.ts` surfaces to the page.

The actual underlying problem is probably one of:

- The Auth0 token doesn't include the `admin` role under the `https://lotg-exams.com/roles` namespace the authorizer expects (Auth0 Action / Rule misconfigured)
- JWKS fetch / token verification is failing
- Some other 401 / 403 path

…but right now the frontend can't show any of that because the browser blocks the response on CORS grounds before JS sees it.

## What this PR does

Adds `aws_api_gateway_gateway_response` for `UNAUTHORIZED`, `ACCESS_DENIED`, `DEFAULT_4XX`, and `DEFAULT_5XX`, all carrying the same CORS headers (`Access-Control-Allow-Origin: *`, `Allow-Headers: Content-Type,Authorization`, `Allow-Methods: GET,POST,PUT,DELETE,OPTIONS`) the success responses use.

After this lands, the failing `/admin/jobs` request will surface as `HTTP 401` / `HTTP 403` (or whatever the real status is) and the page's existing `error` state will show a meaningful message — making the next layer of debugging tractable.

The gateway response IDs are added to the deployment trigger so the change propagates to the active stage.

## Test plan

- [ ] `terraform plan` shows 4 new `aws_api_gateway_gateway_response` resources and a deployment redeploy
- [ ] After apply, `curl -i -H "Origin: https://example.com" <api>/admin/jobs` (no token) returns `401` with `Access-Control-Allow-Origin: *`
- [ ] Logged-in admin reloads `/admin/jobs`. Either:
  - **a.** Page loads (problem was CORS-on-error all along), or
  - **b.** Page shows a real `HTTP 401` / `HTTP 403` message — at which point check CloudWatch for the authorizer Lambda to see the actual rejection reason

## Likely follow-ups

- If the real error turns out to be the roles-namespace mismatch, fix the Auth0 Action / Rule (or the `ROLES_NAMESPACE` constant in `authorize.ts`).
- Long-term: consider locking `Access-Control-Allow-Origin` down to the CloudFront domain instead of `*`.

https://claude.ai/code/session_012ovSD71NbDWLfcCwfsdtE2

---
_Generated by [Claude Code](https://claude.ai/code/session_012ovSD71NbDWLfcCwfsdtE2)_