### PR TITLE
ci: bump Node to 22 and migrate Node-20 actions to v5

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ env:
   AWS_REGION: us-east-1
   AWS_ROLE_ARN: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/lotg-exams-github-actions
   TF_VERSION: 1.10.5
-  NODE_VERSION: 20
+  NODE_VERSION: 22
   TF_VAR_auth0_domain: ${{ secrets.AUTH0_DOMAIN }}
   TF_VAR_auth0_audience: ${{ secrets.AUTH0_AUDIENCE }}
 
@@ -30,7 +30,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check for changes
         uses: dorny/paths-filter@v3
@@ -56,10 +56,10 @@ jobs:
         working-directory: backend
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -91,7 +91,7 @@ jobs:
       has_changes: ${{ steps.plan.outputs.has_changes }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download Lambda Artifacts
         uses: actions/download-artifact@v4
@@ -106,7 +106,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -175,7 +175,7 @@ jobs:
         working-directory: .infra
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download Lambda Artifacts
         uses: actions/download-artifact@v4
@@ -190,7 +190,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -241,7 +241,7 @@ jobs:
       lambda_add_manual_question: ${{ steps.tf-output.outputs.lambda_add_manual_question }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -250,7 +250,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -297,7 +297,7 @@ jobs:
           path: backend/dist
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -409,10 +409,10 @@ jobs:
         working-directory: frontend
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -429,7 +429,7 @@ jobs:
         run: npm run build
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

GitHub Actions runners are deprecating Node 20:

> Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

The warning specifically called out `actions/checkout@v4`, `actions/setup-node@v4`, and `aws-actions/configure-aws-credentials@v4` as Node-20 actions. This PR migrates those to versions that ship on Node 24, and bumps the Node version we install for our own build / release jobs from 20 to 22 (current active LTS).

## Changes

- `actions/checkout@v4` → `@v5`
- `actions/setup-node@v4` → `@v5`
- `aws-actions/configure-aws-credentials@v4` → `@v5`
- `NODE_VERSION: 20` → `22` (`deploy.yml`)
- `node-version: 20` → `22` (`release.yml`)

## What is intentionally **not** changed

- **Lambda runtime** stays at `nodejs20.x` and esbuild target stays at `"node20"` in `backend/build.js`. Deploying nothing-changed artifacts under a newer build env is safer than mixing Lambda runtime + build env in one PR.
- `dorny/paths-filter@v3`, `actions/upload-artifact@v4`, `actions/download-artifact@v4`, `hashicorp/setup-terraform@v3` were not flagged in the deprecation notice and are untouched.

## Follow-ups

- Bump Lambda runtime to `nodejs22.x` (with matching `esbuild` `target: "node22"`) once we want to pick up Node 22 features at runtime.

## Test plan

- [ ] Push triggers build & terraform plan; no Node-20 deprecation warning in the run logs
- [ ] `npm ci` and `npm run build` still succeed for both backend and frontend on Node 22
- [ ] No drift in Lambda function definitions in the `terraform plan` output (runtime unchanged)

https://claude.ai/code/session_012ovSD71NbDWLfcCwfsdtE2

---
_Generated by [Claude Code](https://claude.ai/code/session_012ovSD71NbDWLfcCwfsdtE2)_