### PR TITLE
ci: finish Node 24 migration for remaining actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Check for changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -72,7 +72,7 @@ jobs:
         run: npm run build
 
       - name: Upload Lambda Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lambda-zips
           path: backend/dist/*.zip
@@ -94,19 +94,19 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Download Lambda Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: lambda-zips
           path: backend/dist
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TF_VERSION }}
           terraform_wrapper: false
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -149,7 +149,7 @@ jobs:
 
       - name: Upload Plan (binary)
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: tfplan
           path: .infra/tfplan
@@ -157,7 +157,7 @@ jobs:
 
       - name: Upload Plan (readable)
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: plan-output
           path: .infra/plan_output.txt
@@ -178,19 +178,19 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Download Lambda Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: lambda-zips
           path: backend/dist
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TF_VERSION }}
           terraform_wrapper: false
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -199,7 +199,7 @@ jobs:
         run: terraform init
 
       - name: Download Plan
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: tfplan
           path: .infra
@@ -244,13 +244,13 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TF_VERSION }}
           terraform_wrapper: false
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -291,13 +291,13 @@ jobs:
       needs.get-outputs.result == 'success'
     steps:
       - name: Download Lambda Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: lambda-zips
           path: backend/dist
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -429,7 +429,7 @@ jobs:
         run: npm run build
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
PR #34 only bumped checkout, setup-node, and configure-aws-credentials, but the runner still emits 5 Node-20 deprecation warnings because:

- aws-actions/configure-aws-credentials v5 is still on Node 20; the Node 24 transition was v6.0.0
- dorny/paths-filter@v3, actions/upload-artifact@v4, actions/download-artifact@v4, hashicorp/setup-terraform@v3 were never bumped at all

Migrating each to its first Node-24 major:

- aws-actions/configure-aws-credentials@v5 -> @v6
- dorny/paths-filter@v3 -> @v4
- actions/upload-artifact@v4 -> @v6
- actions/download-artifact@v4 -> @v6
- hashicorp/setup-terraform@v3 -> @v4

setup-terraform@v4 requires runner v2.327.1+, which GitHub-hosted runners satisfy. The aws-actions and artifact major bumps keep the existing input names we use (role-to-assume, aws-region, name, path), so no other workflow changes are needed.

https://claude.ai/code/session_012ovSD71NbDWLfcCwfsdtE2