### PR TITLE
fix(auth): diagnostic logging on authorizer + ship through deploy-bac…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -239,6 +239,7 @@ jobs:
       lambda_publish_quiz: ${{ steps.tf-output.outputs.lambda_publish_quiz }}
       lambda_create_manual_job: ${{ steps.tf-output.outputs.lambda_create_manual_job }}
       lambda_add_manual_question: ${{ steps.tf-output.outputs.lambda_add_manual_question }}
+      lambda_authorize: ${{ steps.tf-output.outputs.lambda_authorize }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -277,6 +278,7 @@ jobs:
           echo "lambda_publish_quiz=$(terraform output -json lambda_function_names | jq -r '.publish_quiz')" >> $GITHUB_OUTPUT
           echo "lambda_create_manual_job=$(terraform output -json lambda_function_names | jq -r '.create_manual_job')" >> $GITHUB_OUTPUT
           echo "lambda_add_manual_question=$(terraform output -json lambda_function_names | jq -r '.add_manual_question')" >> $GITHUB_OUTPUT
+          echo "lambda_authorize=$(terraform output -json lambda_function_names | jq -r '.authorize')" >> $GITHUB_OUTPUT
 
   # Deploy Backend - uses pre-built artifacts
   deploy-backend:
@@ -392,6 +394,13 @@ jobs:
           aws lambda update-function-code \
             --function-name ${{ needs.get-outputs.outputs.lambda_add_manual_question }} \
             --zip-file fileb://backend/dist/addManualQuestion.zip
+
+      - name: Update Lambda - authorize
+        if: needs.get-outputs.outputs.lambda_authorize != '' && needs.get-outputs.outputs.lambda_authorize != 'null'
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ needs.get-outputs.outputs.lambda_authorize }} \
+            --zip-file fileb://backend/dist/authorize.zip
 
   # Build and Deploy Frontend
   deploy-frontend:

--- a/backend/src/handlers/authorize.ts
+++ b/backend/src/handlers/authorize.ts
@@ -9,7 +9,29 @@ import jwksClient from 'jwks-rsa';
 
 const AUTH0_DOMAIN = process.env.AUTH0_DOMAIN;
 const AUTH0_AUDIENCE = process.env.AUTH0_AUDIENCE;
-const ROLES_NAMESPACE = 'https://lotg-exams.com/roles';
+
+// Auth0 custom claims must be namespaced; the project standard is
+// https://lotg-exams.com/roles, but other commonly-seen forms are also
+// checked so a mis-configured Action / Rule still works while we observe
+// what the deployed setup actually puts in the token.
+const PRIMARY_ROLES_NAMESPACE = 'https://lotg-exams.com/roles';
+const FALLBACK_ROLES_CLAIMS = [
+  'https://lotg-exams.com/roles',
+  'https://lotg-exams.com/permissions',
+  'permissions',
+  'roles',
+  'https://schemas.quickconnect.com/identity/claims/role',
+];
+
+function extractRoles(verified: DecodedToken): { roles: string[]; sourceClaim: string | null } {
+  for (const claim of FALLBACK_ROLES_CLAIMS) {
+    const value = verified[claim];
+    if (Array.isArray(value) && value.length > 0) {
+      return { roles: value as string[], sourceClaim: claim };
+    }
+  }
+  return { roles: [], sourceClaim: null };
+}
 
 interface DecodedToken {
   iss: string;
@@ -107,19 +129,24 @@ export async function handler(
       algorithms: ['RS256'],
     }) as DecodedToken;
 
-    // Extract roles from token
-    const roles = (verified[ROLES_NAMESPACE] as string[]) || [];
+    const { roles, sourceClaim } = extractRoles(verified);
     const isAdmin = roles.includes('admin');
 
-    console.log(`Token verified for user: ${verified.sub}, isAdmin: ${isAdmin}`);
+    // Diagnostic logging - prints once per cache miss (5min TTL on the
+    // authorizer). Lets us see what the Auth0 token actually contains
+    // when 401s/403s are reported, without needing to attach a debugger.
+    const claimKeys = Object.keys(verified).filter((k) => k.includes('://') || k === 'permissions' || k === 'roles');
+    console.log(
+      `Token verified sub=${verified.sub} aud=${Array.isArray(verified.aud) ? verified.aud.join(',') : verified.aud} expected_namespace=${PRIMARY_ROLES_NAMESPACE} found_namespace=${sourceClaim ?? '<none>'} roles=${JSON.stringify(roles)} candidate_claims=${JSON.stringify(claimKeys)} isAdmin=${isAdmin}`
+    );
 
-    // For admin routes, require admin role
-    // The methodArn format: arn:aws:execute-api:region:account:api-id/stage/method/resource
     const methodArn = event.methodArn;
     const isAdminRoute = methodArn.includes('/admin/');
 
     if (isAdminRoute && !isAdmin) {
-      console.log('User attempted to access admin route without admin role');
+      console.log(
+        `Denying admin route access: methodArn=${methodArn} sub=${verified.sub} roles=${JSON.stringify(roles)}`
+      );
       return generatePolicy(verified.sub, 'Deny', event.methodArn);
     }
 
@@ -138,7 +165,8 @@ export async function handler(
       roles: roles.join(','),
     });
   } catch (error) {
-    console.error('Token verification failed:', error);
+    const message = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+    console.error(`Token verification failed: ${message}`);
     throw new Error('Unauthorized');
   }
 }


### PR DESCRIPTION
…kend

When PR #33 made API Gateway return CORS-headered errors, the admin pages that previously failed silently with "Failed to fetch" started showing real 401 / 403 responses. Same underlying problem, just visible now.

To work out which check is failing without needing a debugger, this:

1. Logs the verified token's sub, audience, the namespace we expect roles under, the namespace we actually found, and the candidate custom-claim keys present on the token. One log line per cache miss (the API Gateway authorizer caches per token for 5min) so the volume stays low.
2. Tries a small list of common namespaces for the roles claim before giving up - if the Auth0 Action publishes roles under a slightly different name, requests still succeed. The log line records which namespace was actually used, so the canonical PRIMARY_ROLES_NAMESPACE can be reconciled later.
3. Splits the catch-all "Unauthorized" log into the actual error name and message, so "JsonWebTokenError: invalid signature" vs "TokenExpiredError" vs JWKS lookup failures are distinguishable.

The authorize Lambda was missing from the deploy-backend job's update-function-code list, so any backend-only fix to it would never deploy - only an infra change would, via terraform apply rebuilding the zip and re-hashing source_code_hash. Add it to the list and wire its function name through get-outputs so future authorizer changes ship through the normal backend deploy.

https://claude.ai/code/session_012ovSD71NbDWLfcCwfsdtE2