### PR TITLE
chore(backend): bump Lambda runtime to Node.js 24 + AWS provider to v6

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ env:
   AWS_REGION: us-east-1
   AWS_ROLE_ARN: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/lotg-exams-github-actions
   TF_VERSION: 1.10.5
-  NODE_VERSION: 22
+  NODE_VERSION: 24
   TF_VAR_auth0_domain: ${{ secrets.AUTH0_DOMAIN }}
   TF_VAR_auth0_audience: ${{ secrets.AUTH0_AUDIENCE }}
 

--- a/.infra/bootstrap/versions.tf
+++ b/.infra/bootstrap/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/.infra/modules/backend/main.tf
+++ b/.infra/modules/backend/main.tf
@@ -85,7 +85,7 @@ resource "aws_lambda_function" "get_quizzes" {
   function_name    = "${var.project_name}-${var.environment}-getQuizzes"
   role             = aws_iam_role.lambda.arn
   handler          = "index.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   timeout          = 10
   memory_size      = 256
   source_code_hash = fileexists("${path.module}/../../../backend/dist/getQuizzes.zip") ? filebase64sha256("${path.module}/../../../backend/dist/getQuizzes.zip") : null
@@ -108,7 +108,7 @@ resource "aws_lambda_function" "get_quiz" {
   function_name    = "${var.project_name}-${var.environment}-getQuiz"
   role             = aws_iam_role.lambda.arn
   handler          = "index.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   timeout          = 10
   memory_size      = 256
   source_code_hash = fileexists("${path.module}/../../../backend/dist/getQuiz.zip") ? filebase64sha256("${path.module}/../../../backend/dist/getQuiz.zip") : null
@@ -131,7 +131,7 @@ resource "aws_lambda_function" "get_questions" {
   function_name    = "${var.project_name}-${var.environment}-getQuestions"
   role             = aws_iam_role.lambda.arn
   handler          = "index.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   timeout          = 10
   memory_size      = 256
   source_code_hash = fileexists("${path.module}/../../../backend/dist/getQuestions.zip") ? filebase64sha256("${path.module}/../../../backend/dist/getQuestions.zip") : null
@@ -154,7 +154,7 @@ resource "aws_lambda_function" "submit_answers" {
   function_name    = "${var.project_name}-${var.environment}-submitAnswers"
   role             = aws_iam_role.lambda.arn
   handler          = "index.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   timeout          = 10
   memory_size      = 256
   source_code_hash = fileexists("${path.module}/../../../backend/dist/submitAnswers.zip") ? filebase64sha256("${path.module}/../../../backend/dist/submitAnswers.zip") : null
@@ -177,7 +177,7 @@ resource "aws_lambda_function" "authorize" {
   function_name    = "${var.project_name}-${var.environment}-authorize"
   role             = aws_iam_role.lambda.arn
   handler          = "index.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   timeout          = 10
   memory_size      = 256
   source_code_hash = fileexists("${path.module}/../../../backend/dist/authorize.zip") ? filebase64sha256("${path.module}/../../../backend/dist/authorize.zip") : null
@@ -666,7 +666,7 @@ resource "aws_lambda_function" "generate_presigned_url" {
   function_name    = "${var.project_name}-${var.environment}-generatePresignedUrl"
   role             = aws_iam_role.lambda_admin.arn
   handler          = "index.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   timeout          = 10
   memory_size      = 256
   source_code_hash = fileexists("${path.module}/../../../backend/dist/generatePresignedUrl.zip") ? filebase64sha256("${path.module}/../../../backend/dist/generatePresignedUrl.zip") : null
@@ -693,7 +693,7 @@ resource "aws_lambda_function" "process_pdf" {
   function_name    = "${var.project_name}-${var.environment}-processPdf"
   role             = aws_iam_role.lambda_admin.arn
   handler          = "index.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   timeout          = 300  # 5 minutes for PDF processing
   memory_size      = 1024 # More memory for PDF/image processing
   source_code_hash = fileexists("${path.module}/../../../backend/dist/processPdf.zip") ? filebase64sha256("${path.module}/../../../backend/dist/processPdf.zip") : null
@@ -743,7 +743,7 @@ resource "aws_lambda_function" "get_question_bank" {
   function_name    = "${var.project_name}-${var.environment}-getQuestionBank"
   role             = aws_iam_role.lambda_admin.arn
   handler          = "index.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   timeout          = 10
   memory_size      = 256
   source_code_hash = fileexists("${path.module}/../../../backend/dist/getQuestionBank.zip") ? filebase64sha256("${path.module}/../../../backend/dist/getQuestionBank.zip") : null
@@ -769,7 +769,7 @@ resource "aws_lambda_function" "review_question" {
   function_name    = "${var.project_name}-${var.environment}-reviewQuestion"
   role             = aws_iam_role.lambda_admin.arn
   handler          = "index.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   timeout          = 10
   memory_size      = 256
   source_code_hash = fileexists("${path.module}/../../../backend/dist/reviewQuestion.zip") ? filebase64sha256("${path.module}/../../../backend/dist/reviewQuestion.zip") : null
@@ -795,7 +795,7 @@ resource "aws_lambda_function" "bulk_review_questions" {
   function_name    = "${var.project_name}-${var.environment}-bulkReviewQuestions"
   role             = aws_iam_role.lambda_admin.arn
   handler          = "index.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   timeout          = 30 # Longer timeout for batch operations
   memory_size      = 256
   source_code_hash = fileexists("${path.module}/../../../backend/dist/bulkReviewQuestions.zip") ? filebase64sha256("${path.module}/../../../backend/dist/bulkReviewQuestions.zip") : null
@@ -821,7 +821,7 @@ resource "aws_lambda_function" "publish_quiz" {
   function_name    = "${var.project_name}-${var.environment}-publishQuiz"
   role             = aws_iam_role.lambda_admin.arn
   handler          = "index.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   timeout          = 10
   memory_size      = 256
   source_code_hash = fileexists("${path.module}/../../../backend/dist/publishQuiz.zip") ? filebase64sha256("${path.module}/../../../backend/dist/publishQuiz.zip") : null
@@ -847,7 +847,7 @@ resource "aws_lambda_function" "get_extraction_jobs" {
   function_name    = "${var.project_name}-${var.environment}-getExtractionJobs"
   role             = aws_iam_role.lambda_admin.arn
   handler          = "index.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   timeout          = 10
   memory_size      = 256
   source_code_hash = fileexists("${path.module}/../../../backend/dist/getExtractionJobs.zip") ? filebase64sha256("${path.module}/../../../backend/dist/getExtractionJobs.zip") : null
@@ -1138,7 +1138,7 @@ resource "aws_lambda_function" "create_manual_job" {
   function_name    = "${var.project_name}-${var.environment}-createManualJob"
   role             = aws_iam_role.lambda_admin.arn
   handler          = "index.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   timeout          = 10
   memory_size      = 256
   source_code_hash = fileexists("${path.module}/../../../backend/dist/createManualJob.zip") ? filebase64sha256("${path.module}/../../../backend/dist/createManualJob.zip") : null
@@ -1164,7 +1164,7 @@ resource "aws_lambda_function" "add_manual_question" {
   function_name    = "${var.project_name}-${var.environment}-addManualQuestion"
   role             = aws_iam_role.lambda_admin.arn
   handler          = "index.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   timeout          = 10
   memory_size      = 256
   source_code_hash = fileexists("${path.module}/../../../backend/dist/addManualQuestion.zip") ? filebase64sha256("${path.module}/../../../backend/dist/addManualQuestion.zip") : null

--- a/.infra/versions.tf
+++ b/.infra/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 

--- a/backend/build.js
+++ b/backend/build.js
@@ -38,7 +38,7 @@ async function buildHandler(handlerName) {
       entryPoints: [`src/handlers/${handlerName}.ts`],
       bundle: true,
       platform: 'node',
-      target: 'node20',
+      target: 'node24',
       outfile: `dist/${handlerName}/index.js`,
       external: ['@aws-sdk/*'],
       format: 'cjs',


### PR DESCRIPTION
## Summary

Move all 14 Lambda functions to `nodejs24.x` — the current latest Lambda runtime per the [AWS Lambda runtimes table](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) (deprecation Apr 2028 vs Apr 2027 for `nodejs22.x`; `nodejs20.x` is already deprecated as of Apr 30, 2026).

The previous push of this PR failed `terraform validate` with:

```
Error: expected runtime to be one of [...nodejs22.x], got nodejs24.x
```

— because the AWS provider on `~> 5.0` (currently resolving to v5.100.0) hard-codes a Lambda runtime allow-list in its schema that ends at `nodejs22.x`. This PR also bumps the provider so the new runtime validates.

| | Before | After |
|---|---|---|
| Lambda runtime (TF) | `nodejs20.x` × 14 | `nodejs24.x` × 14 |
| esbuild target (`backend/build.js`) | `node20` | `node24` |
| CI build env (`NODE_VERSION` in `deploy.yml`) | `22` | `24` |
| AWS provider (`.infra/versions.tf` + `bootstrap/versions.tf`) | `~> 5.0` | `~> 6.0` |

## v6 breaking-change audit (resources we use)

Verified the two flagged v6 breakages don't affect this codebase:

- **`aws_api_gateway_deployment.{invoke_url, execution_arn}` removed** — we already source `invoke_url` from `aws_api_gateway_stage.this.invoke_url` and `execution_arn` from `aws_api_gateway_rest_api.this.execution_arn`, both of which still exist in v6.
- **`aws_s3_bucket.region` → `bucket_region`** — we don't set `region` on any `aws_s3_bucket` resource.

No usages of OpsWorks / SimpleDB / Worklink / Elastic Transcoder (the dropped services), no `aws_api_gateway_deployment.stage_name` (managed via `aws_api_gateway_stage`).

## Test plan

- [x] `terraform init -upgrade` pulls AWS provider v6.x; `.terraform.lock.hcl` updates if it exists
- [x] `terraform validate` succeeds (was previously failing on `nodejs24.x`)
- [x] `terraform plan` shows 14 in-place `aws_lambda_function` updates (`runtime: nodejs20.x -> nodejs24.x`) and a provider-version change; **no resource replacement**
- [ ] After apply, Lambdas cold-start cleanly (no "Runtime exited" / module-load errors in CloudWatch)
- [ ] Public quiz flow works (`/`, `/quiz/:id`, `/quiz/:id/results`)
- [ ] Build job succeeds with Node 24 (`npm ci`, `npm run build`)

## Rollback

Revert the PR. The provider drops back to `~> 5.0` and Lambda runtimes drop back to `nodejs20.x`.

https://claude.ai/code/session_012ovSD71NbDWLfcCwfsdtE2