### PR TITLE
fix(deploy): eliminate SPA stale-asset race in frontend deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -443,15 +443,44 @@ jobs:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Sync to S3
+      # Two-phase upload to avoid the SPA stale-asset race:
+      # Vite emits content-hashed files under dist/assets/ that are
+      # immutable, plus dist/index.html which references the latest
+      # hashes. If we did `aws s3 sync --delete` in one shot, old
+      # hashed assets would be removed before CloudFront finished
+      # invalidating, and any user with a cached index.html would 404
+      # on the asset they reference.
+      #
+      # Instead:
+      #   1. Upload assets first, no --delete, with a long immutable
+      #      cache header so the browser keeps them forever.
+      #   2. Upload everything else (incl. index.html) with no-cache
+      #      so the browser always re-validates the entry point.
+      #   3. Invalidate CloudFront for index.html and the root path,
+      #      not /*, since hashed assets are immutable and don't need
+      #      invalidation.
+      #
+      # Old hashed assets are intentionally not deleted - they cost
+      # very little and provide a grace window for users still on a
+      # cached index.html. Periodic cleanup can be a separate job.
+      - name: Sync hashed assets (immutable, 1 year)
         run: |
-          aws s3 sync dist/ s3://${{ needs.get-outputs.outputs.s3_bucket }} --delete
+          aws s3 sync dist/assets/ s3://${{ needs.get-outputs.outputs.s3_bucket }}/assets/ \
+            --cache-control "public, max-age=31536000, immutable" \
+            --no-progress
 
-      - name: Invalidate CloudFront Cache
+      - name: Sync entry point and root files (no cache)
+        run: |
+          aws s3 sync dist/ s3://${{ needs.get-outputs.outputs.s3_bucket }}/ \
+            --exclude "assets/*" \
+            --cache-control "no-cache, must-revalidate" \
+            --no-progress
+
+      - name: Invalidate CloudFront Cache (index.html only)
         run: |
           aws cloudfront create-invalidation \
             --distribution-id ${{ needs.get-outputs.outputs.cloudfront_id }} \
-            --paths "/*"
+            --paths "/" "/index.html"
 
   # Deployment Summary
   deployment-summary:


### PR DESCRIPTION
## The 404 you're seeing on /admin/questions

The previous deploy-frontend step ran:

```yaml
aws s3 sync dist/ s3://... --delete
aws cloudfront create-invalidation ... --paths "/*"
```

There's a race between (a) `--delete` removing the *old* hashed asset files from S3, and (b) CloudFront propagating the *new* `index.html`. Inside that window:

1. User's browser has cached the old `index.html` referencing `assets/index-OLDHASH.js`.
2. `--delete` already wiped `assets/index-OLDHASH.js` from S3.
3. Browser requests `assets/index-OLDHASH.js`. CloudFront → S3 → 404.
4. CloudFront's `custom_error_response` rewrites the 404 to `/index.html` with status 200.
5. Browser receives HTML where it expected JavaScript. SPA can't boot. User sees a blank screen / "404" / broken page.

This is the same `"trigger fresh deployment to resolve stale asset mismatch"` issue that commit `4f0703c` worked around by hand last time.

## What this PR does

Splits the single sync into two phases and stops using `--delete`:

1. **Sync `dist/assets/`** (immutable hashed bundles) with `Cache-Control: public, max-age=31536000, immutable`. **No `--delete`.** Old hashed assets stay in S3 — they're immutable, never collide with new builds, and give users on a cached `index.html` a grace window.
2. **Sync everything else** (incl. `index.html`) with `Cache-Control: no-cache, must-revalidate` so browsers always re-fetch the entry point.
3. **Invalidate only `/` and `/index.html`** — hashed assets don't need invalidation.

## Trade-off

Old asset bundles accumulate in S3 forever. Cost is negligible at this scale; if it ever matters, a periodic lifecycle rule that expires objects in `assets/` older than N days would handle it without re-introducing the race.

## Test plan

- [ ] Merge → push triggers `deploy-frontend`. Both sync steps complete, invalidation succeeds.
- [ ] Hard-refresh the site after deploy; index.html and assets all load.
- [ ] Visit `/admin/questions` directly (not via in-app navigation). Page loads instead of returning 404.
- [ ] Open DevTools → Network → reload. Confirm `index.html` has `cache-control: no-cache, must-revalidate` and `/assets/index-*.js` has `cache-control: public, max-age=31536000, immutable`.
- [ ] List the bucket; old hashed asset files from previous deploys are still present (this is expected and desired).

https://claude.ai/code/session_012ovSD71NbDWLfcCwfsdtE2

---
_Generated by [Claude Code](https://claude.ai/code/session_012ovSD71NbDWLfcCwfsdtE2)_