### PR TITLE
fix: add Auth0 audience to fix admin endpoint 404s

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -426,6 +426,7 @@ jobs:
           VITE_API_URL: ${{ needs.get-outputs.outputs.api_url }}
           VITE_AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
           VITE_AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
+          VITE_AUTH0_AUDIENCE: ${{ secrets.AUTH0_AUDIENCE }}
         run: npm run build
 
       - name: Configure AWS Credentials

--- a/.infra/modules/backend/main.tf
+++ b/.infra/modules/backend/main.tf
@@ -411,11 +411,19 @@ resource "aws_api_gateway_deployment" "this" {
   triggers = {
     redeployment = sha1(jsonencode([
       aws_api_gateway_resource.quizzes.id,
+      aws_api_gateway_resource.quiz_id.id,
+      aws_api_gateway_resource.questions.id,
       aws_api_gateway_resource.submit.id,
       aws_api_gateway_resource.admin.id,
+      aws_api_gateway_resource.admin_upload.id,
       aws_api_gateway_resource.admin_presigned_url.id,
       aws_api_gateway_resource.admin_jobs.id,
+      aws_api_gateway_resource.admin_job_id.id,
+      aws_api_gateway_resource.admin_job_publish.id,
       aws_api_gateway_resource.admin_questions.id,
+      aws_api_gateway_resource.admin_question_id.id,
+      aws_api_gateway_resource.admin_question_review.id,
+      aws_api_gateway_resource.admin_bulk_review.id,
       aws_api_gateway_resource.admin_jobs_manual.id,
       aws_api_gateway_resource.admin_job_questions.id,
     ]))

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -4,3 +4,4 @@ VITE_API_URL=https://your-api-gateway-url.amazonaws.com/prod
 # Auth0 Configuration
 VITE_AUTH0_DOMAIN=your-tenant.auth0.com
 VITE_AUTH0_CLIENT_ID=your-client-id
+VITE_AUTH0_AUDIENCE=https://your-api-identifier

--- a/frontend/src/hooks/useAccessToken.ts
+++ b/frontend/src/hooks/useAccessToken.ts
@@ -15,7 +15,9 @@ export function useAccessToken() {
       }
 
       try {
-        const accessToken = await getAccessTokenSilently();
+        const accessToken = await getAccessTokenSilently({
+          authorizationParams: { audience: import.meta.env.VITE_AUTH0_AUDIENCE },
+        });
         setToken(accessToken);
       } catch (err) {
         setError(err instanceof Error ? err : new Error('Failed to get token'));
@@ -31,7 +33,9 @@ export function useAccessToken() {
     if (!isAuthenticated) {
       throw new Error('Not authenticated');
     }
-    return getAccessTokenSilently();
+    return getAccessTokenSilently({
+      authorizationParams: { audience: import.meta.env.VITE_AUTH0_AUDIENCE },
+    });
   }, [getAccessTokenSilently, isAuthenticated]);
 
   return { token, loading, error, getToken };

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,7 @@ import './styles/index.css';
 
 const domain = import.meta.env.VITE_AUTH0_DOMAIN;
 const clientId = import.meta.env.VITE_AUTH0_CLIENT_ID;
+const audience = import.meta.env.VITE_AUTH0_AUDIENCE;
 
 // Validate Auth0 configuration at startup
 if (!domain || !clientId) {
@@ -23,6 +24,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
         clientId={clientId}
         authorizationParams={{
           redirect_uri: window.location.origin,
+          audience: audience,
         }}
       >
         <App />


### PR DESCRIPTION
## Problem

Admin API endpoints return 404/403 errors after login. Root causes:

1. **Missing Auth0 audience** — `Auth0Provider` wasn't passing `audience` to `authorizationParams`, so `getAccessTokenSilently()` returned an opaque token instead of a JWT. The Lambda authorizer can't verify opaque tokens against Auth0's JWKS, causing it to throw `Unauthorized`.

2. **Stale API Gateway deployment** — The `triggers.redeployment` hash in Terraform only included 8 of the 16 API Gateway resources. Any new routes added after the initial deploy wouldn't trigger a redeployment, leaving them unreachable (404).

3. **CI missing `VITE_AUTH0_AUDIENCE`** — The `deploy-frontend` build step didn't pass the audience env var, so production builds had the same missing-audience bug.

## Changes

- `frontend/src/main.tsx`: pass `audience` to `Auth0Provider.authorizationParams`
- `frontend/src/hooks/useAccessToken.ts`: pass `audience` to both `getAccessTokenSilently` calls
- `frontend/.env.example`: document `VITE_AUTH0_AUDIENCE`
- `.infra/modules/backend/main.tf`: fix deployment trigger hash to include all 16 API Gateway resources
- `.github/workflows/deploy.yml`: add `VITE_AUTH0_AUDIENCE` to frontend build step

## Required action

Add `AUTH0_AUDIENCE` to GitHub repository secrets (same value as `TF_VAR_auth0_audience` which is already set). Also add it to your local `frontend/.env` file.

## What triggers on merge

- `.infra/` changed → Terraform plan/apply (requires production environment approval) → forces API Gateway redeployment
- `frontend/` changed → frontend rebuild and S3/CloudFront deploy