### PR TITLE
fix: remove Auth0 audience requirement

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,6 @@ env:
   TF_VERSION: 1.10.5
   NODE_VERSION: 24
   TF_VAR_auth0_domain: ${{ secrets.AUTH0_DOMAIN }}
-  TF_VAR_auth0_audience: ${{ secrets.AUTH0_AUDIENCE }}
 
 jobs:
   # Detect which folders have changes
@@ -435,7 +434,6 @@ jobs:
           VITE_API_URL: ${{ needs.get-outputs.outputs.api_url }}
           VITE_AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
           VITE_AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
-          VITE_AUTH0_AUDIENCE: ${{ secrets.AUTH0_AUDIENCE }}
         run: npm run build
 
       - name: Configure AWS Credentials

--- a/.infra/main.tf
+++ b/.infra/main.tf
@@ -28,7 +28,6 @@ module "backend" {
   dynamodb_table_name = module.database.table_name
   dynamodb_table_arn  = module.database.table_arn
   auth0_domain        = var.auth0_domain
-  auth0_audience      = var.auth0_audience
 }
 
 # Frontend module - S3 + CloudFront

--- a/.infra/modules/backend/main.tf
+++ b/.infra/modules/backend/main.tf
@@ -184,9 +184,8 @@ resource "aws_lambda_function" "authorize" {
 
   environment {
     variables = {
-      AUTH0_DOMAIN   = var.auth0_domain
-      AUTH0_AUDIENCE = var.auth0_audience
-      NODE_ENV       = var.environment
+      AUTH0_DOMAIN = var.auth0_domain
+      NODE_ENV     = var.environment
     }
   }
 

--- a/.infra/modules/backend/variables.tf
+++ b/.infra/modules/backend/variables.tf
@@ -33,8 +33,4 @@ variable "auth0_domain" {
   nullable    = false
 }
 
-variable "auth0_audience" {
-  description = "Auth0 API audience identifier"
-  type        = string
-  nullable    = false
-}
+

--- a/.infra/variables.tf
+++ b/.infra/variables.tf
@@ -43,8 +43,4 @@ variable "auth0_domain" {
   nullable    = false
 }
 
-variable "auth0_audience" {
-  description = "Auth0 API audience identifier"
-  type        = string
-  nullable    = false
-}
+

--- a/backend/src/handlers/authorize.ts
+++ b/backend/src/handlers/authorize.ts
@@ -8,7 +8,6 @@ import jwt from 'jsonwebtoken';
 import jwksClient from 'jwks-rsa';
 
 const AUTH0_DOMAIN = process.env.AUTH0_DOMAIN;
-const AUTH0_AUDIENCE = process.env.AUTH0_AUDIENCE;
 
 // Auth0 custom claims must be namespaced; the project standard is
 // https://lotg-exams.com/roles, but other commonly-seen forms are also
@@ -99,8 +98,8 @@ export async function handler(
 ): Promise<APIGatewayAuthorizerResult> {
   console.log('Authorizer invoked');
 
-  if (!AUTH0_DOMAIN || !AUTH0_AUDIENCE) {
-    console.error('Missing AUTH0_DOMAIN or AUTH0_AUDIENCE environment variables');
+  if (!AUTH0_DOMAIN) {
+    console.error('Missing AUTH0_DOMAIN environment variable');
     throw new Error('Unauthorized');
   }
 
@@ -124,7 +123,6 @@ export async function handler(
 
     // Verify token
     const verified = jwt.verify(token, signingKey, {
-      audience: AUTH0_AUDIENCE,
       issuer: `https://${AUTH0_DOMAIN}/`,
       algorithms: ['RS256'],
     }) as DecodedToken;
@@ -135,7 +133,9 @@ export async function handler(
     // Diagnostic logging - prints once per cache miss (5min TTL on the
     // authorizer). Lets us see what the Auth0 token actually contains
     // when 401s/403s are reported, without needing to attach a debugger.
-    const claimKeys = Object.keys(verified).filter((k) => k.includes('://') || k === 'permissions' || k === 'roles');
+    const claimKeys = Object.keys(verified).filter(
+      (k) => k.includes('://') || k === 'permissions' || k === 'roles'
+    );
     console.log(
       `Token verified sub=${verified.sub} aud=${Array.isArray(verified.aud) ? verified.aud.join(',') : verified.aud} expected_namespace=${PRIMARY_ROLES_NAMESPACE} found_namespace=${sourceClaim ?? '<none>'} roles=${JSON.stringify(roles)} candidate_claims=${JSON.stringify(claimKeys)} isAdmin=${isAdmin}`
     );

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -4,4 +4,3 @@ VITE_API_URL=https://your-api-gateway-url.amazonaws.com/prod
 # Auth0 Configuration
 VITE_AUTH0_DOMAIN=your-tenant.auth0.com
 VITE_AUTH0_CLIENT_ID=your-client-id
-VITE_AUTH0_AUDIENCE=https://your-api-identifier

--- a/frontend/src/hooks/useAccessToken.ts
+++ b/frontend/src/hooks/useAccessToken.ts
@@ -15,9 +15,7 @@ export function useAccessToken() {
       }
 
       try {
-        const accessToken = await getAccessTokenSilently({
-          authorizationParams: { audience: import.meta.env.VITE_AUTH0_AUDIENCE },
-        });
+        const accessToken = await getAccessTokenSilently();
         setToken(accessToken);
       } catch (err) {
         setError(err instanceof Error ? err : new Error('Failed to get token'));
@@ -33,9 +31,7 @@ export function useAccessToken() {
     if (!isAuthenticated) {
       throw new Error('Not authenticated');
     }
-    return getAccessTokenSilently({
-      authorizationParams: { audience: import.meta.env.VITE_AUTH0_AUDIENCE },
-    });
+    return getAccessTokenSilently();
   }, [getAccessTokenSilently, isAuthenticated]);
 
   return { token, loading, error, getToken };

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,7 +7,6 @@ import './styles/index.css';
 
 const domain = import.meta.env.VITE_AUTH0_DOMAIN;
 const clientId = import.meta.env.VITE_AUTH0_CLIENT_ID;
-const audience = import.meta.env.VITE_AUTH0_AUDIENCE;
 
 // Validate Auth0 configuration at startup
 if (!domain || !clientId) {
@@ -24,7 +23,6 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
         clientId={clientId}
         authorizationParams={{
           redirect_uri: window.location.origin,
-          audience: audience,
         }}
       >
         <App />


### PR DESCRIPTION
No Auth0 API is registered for this app (SPA only), so audience validation was always going to fail. Removes `AUTH0_AUDIENCE` from everywhere:

- Lambda authorizer: drop env var check and `audience` from `jwt.verify` (issuer + signature still validated)
- Frontend: remove `audience` from `Auth0Provider` and `getAccessTokenSilently`
- Terraform: remove `auth0_audience` variable from root, backend module, and module call
- CI: remove `TF_VAR_auth0_audience` and `VITE_AUTH0_AUDIENCE` from workflow
- `.env.example`: remove `VITE_AUTH0_AUDIENCE`

On merge: Terraform apply will update the Lambda env vars, backend redeploys with the fixed authorizer, frontend redeploys without the audience param.