### PR TITLE
fix: use ID token for admin API authentication

### DIFF
--- a/frontend/src/hooks/useAccessToken.ts
+++ b/frontend/src/hooks/useAccessToken.ts
@@ -2,7 +2,7 @@ import { useAuth0 } from '@auth0/auth0-react';
 import { useCallback, useState, useEffect } from 'react';
 
 export function useAccessToken() {
-  const { getAccessTokenSilently, isAuthenticated } = useAuth0();
+  const { getIdTokenClaims, isAuthenticated } = useAuth0();
   const [token, setToken] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -15,8 +15,8 @@ export function useAccessToken() {
       }
 
       try {
-        const accessToken = await getAccessTokenSilently();
-        setToken(accessToken);
+        const claims = await getIdTokenClaims();
+        setToken(claims?.__raw ?? null);
       } catch (err) {
         setError(err instanceof Error ? err : new Error('Failed to get token'));
       } finally {
@@ -25,14 +25,16 @@ export function useAccessToken() {
     }
 
     fetchToken();
-  }, [getAccessTokenSilently, isAuthenticated]);
+  }, [getIdTokenClaims, isAuthenticated]);
 
   const getToken = useCallback(async () => {
     if (!isAuthenticated) {
       throw new Error('Not authenticated');
     }
-    return getAccessTokenSilently();
-  }, [getAccessTokenSilently, isAuthenticated]);
+    const claims = await getIdTokenClaims();
+    if (!claims?.__raw) throw new Error('No ID token available');
+    return claims.__raw;
+  }, [getIdTokenClaims, isAuthenticated]);
 
   return { token, loading, error, getToken };
 }

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -23,7 +23,7 @@ const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
  * Use this for admin endpoints that require authentication.
  */
 export function useApi() {
-  const { getAccessTokenSilently, isAuthenticated } = useAuth0();
+  const { getIdTokenClaims, isAuthenticated } = useAuth0();
 
   const fetchWithAuth = useCallback(
     async <T>(endpoint: string, options?: RequestInit): Promise<T> => {
@@ -35,11 +35,10 @@ export function useApi() {
       // Add auth header if authenticated
       if (isAuthenticated) {
         try {
-          const token = await getAccessTokenSilently();
-          headers['Authorization'] = `Bearer ${token}`;
+          const claims = await getIdTokenClaims();
+          if (claims?.__raw) headers['Authorization'] = `Bearer ${claims.__raw}`;
         } catch {
-          // Token fetch failed, continue without auth
-          console.warn('Failed to get access token');
+          console.warn('Failed to get ID token');
         }
       }
 
@@ -55,7 +54,7 @@ export function useApi() {
 
       return response.json();
     },
-    [getAccessTokenSilently, isAuthenticated]
+    [getIdTokenClaims, isAuthenticated]
   );
 
   // Admin endpoints with authentication


### PR DESCRIPTION
## Root cause

Without an Auth0 API registered, `getAccessTokenSilently()` returns an **opaque** access token (not a JWT). The Lambda authorizer calls `jwt.decode()` on it, gets `null`, and throws `Unauthorized` — which is why the authorizer Lambda never even logs anything for today's requests.

The **ID token** is always a signed JWT regardless of whether an API is registered, and is verifiable against Auth0's JWKS endpoint with the same issuer check.

## Changes

- `useAccessToken.ts`: switch from `getAccessTokenSilently` → `getIdTokenClaims().__raw`
- `useApi.ts`: same switch in `fetchWithAuth`

Only frontend changes — no infra or backend deploy needed, just a frontend redeploy.