### PR TITLE
feat: add isPublic flag for freemium quiz access

### DIFF
--- a/backend/src/handlers/getQuizzes.ts
+++ b/backend/src/handlers/getQuizzes.ts
@@ -30,9 +30,12 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
       description: job.description?.trim() || `Questions extracted from ${job.fileName}`,
       category: job.category || 'Laws of the Game',
       questionCount: job.approvedCount,
+      isPublic: job.isPublic ?? false,
       ...(job.timeLimitMinutes !== undefined && { timeLimitMinutes: job.timeLimitMinutes }),
       ...(job.lawFilter !== undefined && { lawFilter: job.lawFilter }),
-      ...(job.questionsPerAttempt !== undefined && { questionsPerAttempt: job.questionsPerAttempt }),
+      ...(job.questionsPerAttempt !== undefined && {
+        questionsPerAttempt: job.questionsPerAttempt,
+      }),
     }));
 
     return successResponse(summaries);

--- a/backend/src/handlers/publishQuiz.ts
+++ b/backend/src/handlers/publishQuiz.ts
@@ -4,6 +4,7 @@ import { successResponse, errorResponse } from '../lib/response.js';
 
 interface PublishRequest {
   publish: boolean;
+  isPublic?: boolean;
 }
 
 /**
@@ -49,7 +50,7 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
     }
 
     if (shouldPublish) {
-      await publishJob(jobId);
+      await publishJob(jobId, request.isPublic ?? false);
     } else {
       await unpublishJob(jobId);
     }
@@ -57,9 +58,8 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
     return successResponse({
       jobId,
       published: shouldPublish,
-      message: shouldPublish
-        ? 'Quiz published successfully'
-        : 'Quiz unpublished successfully',
+      isPublic: shouldPublish ? (request.isPublic ?? false) : false,
+      message: shouldPublish ? 'Quiz published successfully' : 'Quiz unpublished successfully',
     });
   } catch (error) {
     console.error('Error publishing job:', error);

--- a/backend/src/lib/dynamodb.ts
+++ b/backend/src/lib/dynamodb.ts
@@ -239,7 +239,8 @@ export async function updateBankQuestionStatus(
       PK: `QUESTION#${questionId}`,
       SK: 'METADATA',
     },
-    UpdateExpression: 'SET #status = :status, updatedAt = :updatedAt, reviewedAt = :reviewedAt, reviewedBy = :reviewedBy',
+    UpdateExpression:
+      'SET #status = :status, updatedAt = :updatedAt, reviewedAt = :reviewedAt, reviewedBy = :reviewedBy',
     ExpressionAttributeNames: {
       '#status': 'status',
     },
@@ -297,9 +298,7 @@ export async function getQuestionsByLaw(
   } = {
     TableName: TABLE_NAME,
     IndexName: 'Law-Status-index',
-    KeyConditionExpression: status
-      ? '#law = :law AND #status = :status'
-      : '#law = :law',
+    KeyConditionExpression: status ? '#law = :law AND #status = :status' : '#law = :law',
     ExpressionAttributeNames: {
       '#law': 'law',
       ...(status && { '#status': 'status' }),
@@ -428,16 +427,17 @@ export async function getPublishedJobs(): Promise<ExtractionJobItem[]> {
 /**
  * Publish a job (make it visible as a quiz on the homepage)
  */
-export async function publishJob(jobId: string): Promise<void> {
+export async function publishJob(jobId: string, isPublic = false): Promise<void> {
   const params = {
     TableName: TABLE_NAME,
     Key: {
       PK: `JOB#${jobId}`,
       SK: 'METADATA',
     },
-    UpdateExpression: 'SET published = :published, updatedAt = :updatedAt',
+    UpdateExpression: 'SET published = :published, isPublic = :isPublic, updatedAt = :updatedAt',
     ExpressionAttributeValues: {
       ':published': true,
+      ':isPublic': isPublic,
       ':updatedAt': new Date().toISOString(),
     },
   };
@@ -481,7 +481,8 @@ export async function updateQuestionUsage(questionIds: string[]): Promise<void> 
             PK: `QUESTION#${questionId}`,
             SK: 'METADATA',
           },
-          UpdateExpression: 'SET usageCount = if_not_exists(usageCount, :zero) + :inc, lastUsedAt = :now',
+          UpdateExpression:
+            'SET usageCount = if_not_exists(usageCount, :zero) + :inc, lastUsedAt = :now',
           ExpressionAttributeValues: {
             ':zero': 0,
             ':inc': 1,

--- a/backend/src/lib/types.ts
+++ b/backend/src/lib/types.ts
@@ -35,10 +35,23 @@ export type Difficulty = 'easy' | 'medium' | 'hard';
 export type JobSource = 'pdf_extraction' | 'manual_entry';
 
 export type Law =
-  | 'Law 1' | 'Law 2' | 'Law 3' | 'Law 4' | 'Law 5'
-  | 'Law 6' | 'Law 7' | 'Law 8' | 'Law 9' | 'Law 10'
-  | 'Law 11' | 'Law 12' | 'Law 13' | 'Law 14' | 'Law 15'
-  | 'Law 16' | 'Law 17';
+  | 'Law 1'
+  | 'Law 2'
+  | 'Law 3'
+  | 'Law 4'
+  | 'Law 5'
+  | 'Law 6'
+  | 'Law 7'
+  | 'Law 8'
+  | 'Law 9'
+  | 'Law 10'
+  | 'Law 11'
+  | 'Law 12'
+  | 'Law 13'
+  | 'Law 14'
+  | 'Law 15'
+  | 'Law 16'
+  | 'Law 17';
 
 export interface BankQuestionItem {
   PK: string; // QUESTION#{questionId}
@@ -84,6 +97,7 @@ export interface ExtractionJobItem {
   rejectedCount: number;
   duplicateCount: number;
   published?: boolean;
+  isPublic?: boolean; // true = unauthenticated users can take this quiz
   errorMessage?: string;
   createdAt: string;
   updatedAt: string;
@@ -105,6 +119,7 @@ export interface QuizSummary {
   description: string;
   category: string;
   questionCount: number;
+  isPublic?: boolean;
   timeLimitMinutes?: number;
   lawFilter?: Law;
   questionsPerAttempt?: number;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -183,13 +183,14 @@ export async function bulkReviewQuestions(
 export async function publishQuiz(
   jobId: string,
   token: string,
-  publish = true
+  publish = true,
+  isPublic = false
 ): Promise<PublishResponse> {
   return fetchAPI<PublishResponse>(
     `/admin/jobs/${jobId}/publish`,
     {
       method: 'PUT',
-      body: JSON.stringify({ publish }),
+      body: JSON.stringify({ publish, isPublic }),
     },
     token
   );

--- a/frontend/src/pages/QuizList.tsx
+++ b/frontend/src/pages/QuizList.tsx
@@ -40,10 +40,7 @@ export default function QuizList() {
     return quizzes.filter((q) => {
       if (category !== ALL_CATEGORIES && q.category !== category) return false;
       if (!needle) return true;
-      return (
-        q.title.toLowerCase().includes(needle) ||
-        q.description.toLowerCase().includes(needle)
-      );
+      return q.title.toLowerCase().includes(needle) || q.description.toLowerCase().includes(needle);
     });
   }, [quizzes, search, category]);
 
@@ -75,9 +72,7 @@ export default function QuizList() {
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl">
       <header className="mb-6">
-        <h1 className="text-4xl font-bold text-gray-900 mb-2">
-          Laws of the Game Quizzes
-        </h1>
+        <h1 className="text-4xl font-bold text-gray-900 mb-2">Laws of the Game Quizzes</h1>
         <p className="text-lg text-gray-600">
           Test your knowledge of football's Laws of the Game (IFAB)
         </p>
@@ -149,18 +144,21 @@ export default function QuizList() {
       ) : (
         <div className="grid gap-6 md:grid-cols-2">
           {filtered.map((quiz) => (
-            <Link
-              key={quiz.quizId}
-              to={`/quiz/${quiz.quizId}`}
-              className="card-hover group"
-            >
+            <Link key={quiz.quizId} to={`/quiz/${quiz.quizId}`} className="card-hover group">
               <div className="flex items-start justify-between mb-3">
                 <h2 className="text-xl font-semibold text-gray-900 group-hover:text-primary-600 transition-colors">
                   {quiz.title}
                 </h2>
-                <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-primary-100 text-primary-800">
-                  {quiz.questionCount} questions
-                </span>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  {!quiz.isPublic && (
+                    <span title="Login required" className="text-gray-400">
+                      🔒
+                    </span>
+                  )}
+                  <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-primary-100 text-primary-800">
+                    {quiz.questionCount} questions
+                  </span>
+                </div>
               </div>
               <p className="text-gray-600 mb-4">{quiz.description}</p>
               <div className="flex items-center justify-between">

--- a/frontend/src/pages/admin/JobDetail.tsx
+++ b/frontend/src/pages/admin/JobDetail.tsx
@@ -38,11 +38,28 @@ export default function AdminJobDetail() {
     try {
       const token = await getToken();
       const newPublishedState = !job.published;
-      await publishQuiz(jobId, token, newPublishedState);
+      await publishQuiz(jobId, token, newPublishedState, job.isPublic ?? false);
       setJob({ ...job, published: newPublishedState });
     } catch (err) {
       console.error('Publish failed:', err);
       alert(err instanceof Error ? err.message : 'Failed to update publish status');
+    } finally {
+      setPublishing(false);
+    }
+  };
+
+  const handleTogglePublic = async () => {
+    if (!jobId || !job || !job.published) return;
+
+    setPublishing(true);
+    try {
+      const token = await getToken();
+      const newIsPublic = !job.isPublic;
+      await publishQuiz(jobId, token, true, newIsPublic);
+      setJob({ ...job, isPublic: newIsPublic });
+    } catch (err) {
+      console.error('Toggle public failed:', err);
+      alert(err instanceof Error ? err.message : 'Failed to update visibility');
     } finally {
       setPublishing(false);
     }
@@ -149,6 +166,22 @@ export default function AdminJobDetail() {
                 }`}
               >
                 {publishing ? 'Updating...' : job.published ? 'Unpublish Quiz' : 'Publish Quiz'}
+              </button>
+            )}
+            {job.published && (
+              <button
+                onClick={handleTogglePublic}
+                disabled={publishing}
+                title={
+                  job.isPublic ? 'Click to make login required' : 'Click to allow public access'
+                }
+                className={`px-4 py-2 rounded-lg font-medium transition-colors disabled:opacity-50 ${
+                  job.isPublic
+                    ? 'bg-blue-100 text-blue-800 hover:bg-blue-200'
+                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                }`}
+              >
+                {job.isPublic ? '🌐 Public' : '🔒 Login Required'}
               </button>
             )}
             {job.published && (

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -4,6 +4,7 @@ export interface QuizSummary {
   description: string;
   category: string;
   questionCount: number;
+  isPublic?: boolean;
   timeLimitMinutes?: number;
   lawFilter?: Law;
   questionsPerAttempt?: number;
@@ -44,10 +45,23 @@ export type Difficulty = 'easy' | 'medium' | 'hard';
 export type JobSource = 'pdf_extraction' | 'manual_entry';
 
 export type Law =
-  | 'Law 1' | 'Law 2' | 'Law 3' | 'Law 4' | 'Law 5'
-  | 'Law 6' | 'Law 7' | 'Law 8' | 'Law 9' | 'Law 10'
-  | 'Law 11' | 'Law 12' | 'Law 13' | 'Law 14' | 'Law 15'
-  | 'Law 16' | 'Law 17';
+  | 'Law 1'
+  | 'Law 2'
+  | 'Law 3'
+  | 'Law 4'
+  | 'Law 5'
+  | 'Law 6'
+  | 'Law 7'
+  | 'Law 8'
+  | 'Law 9'
+  | 'Law 10'
+  | 'Law 11'
+  | 'Law 12'
+  | 'Law 13'
+  | 'Law 14'
+  | 'Law 15'
+  | 'Law 16'
+  | 'Law 17';
 
 export interface BankQuestion {
   questionId: string;
@@ -83,6 +97,7 @@ export interface ExtractionJob {
   rejectedCount: number;
   duplicateCount: number;
   published?: boolean;
+  isPublic?: boolean;
   errorMessage?: string;
   createdAt: string;
   completedAt?: string;
@@ -145,6 +160,7 @@ export interface BulkReviewResponse {
 export interface PublishResponse {
   jobId: string;
   published: boolean;
+  isPublic?: boolean;
   message: string;
 }
 


### PR DESCRIPTION
Implements the data model and UI for issue #10 (freemium access).

## What's added

**Backend:**
- `isPublic` field on `ExtractionJobItem` type (defaults to `false` — no behaviour change for existing quizzes)
- `publishJob(jobId, isPublic)` stores the flag in DynamoDB
- `PUT /admin/jobs/{id}/publish` accepts `isPublic` in request body
- `GET /quizzes` includes `isPublic` in each quiz summary

**Admin UI (JobDetail):**
- After publishing, a '🌐 Public' / '🔒 Login Required' toggle button appears
- Clicking it calls the publish endpoint with the flipped `isPublic` value

**Public UI (QuizList):**
- Quizzes with `isPublic: false` show a 🔒 icon on their card

## What's NOT in this PR
Access enforcement (blocking unauthenticated users from taking locked quizzes) is deferred — that requires auth middleware on the quiz-taking flow and is tracked separately in #10.

Closes #10 (partial)