### PR TITLE
fix: improve locked quiz UX and change MCQ labels to A-D

### DIFF
--- a/frontend/src/pages/QuizList.tsx
+++ b/frontend/src/pages/QuizList.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useAuth0 } from '@auth0/auth0-react';
 import { getQuizzes } from '../api/client';
 import type { QuizSummary } from '../types';
 
 const ALL_CATEGORIES = '__all__';
 
 export default function QuizList() {
+  const { isAuthenticated } = useAuth0();
   const [quizzes, setQuizzes] = useState<QuizSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -143,32 +145,45 @@ export default function QuizList() {
         </div>
       ) : (
         <div className="grid gap-6 md:grid-cols-2">
-          {filtered.map((quiz) => (
-            <Link key={quiz.quizId} to={`/quiz/${quiz.quizId}`} className="card-hover group">
-              <div className="flex items-start justify-between mb-3">
-                <h2 className="text-xl font-semibold text-gray-900 group-hover:text-primary-600 transition-colors">
-                  {quiz.title}
-                </h2>
-                <div className="flex items-center gap-2 flex-shrink-0">
-                  {!quiz.isPublic && (
-                    <span title="Login required" className="text-gray-400">
-                      🔒
+          {filtered.map((quiz) => {
+            const locked = !quiz.isPublic && !isAuthenticated;
+            return (
+              <Link
+                key={quiz.quizId}
+                to={locked ? '#' : `/quiz/${quiz.quizId}`}
+                onClick={locked ? (e) => e.preventDefault() : undefined}
+                className={`card-hover group ${locked ? 'opacity-50 grayscale pointer-events-auto cursor-not-allowed' : ''}`}
+                aria-disabled={locked}
+              >
+                <div className="flex items-start justify-between mb-3">
+                  <h2 className="text-xl font-semibold text-gray-900 group-hover:text-primary-600 transition-colors">
+                    {quiz.title}
+                  </h2>
+                  <div className="flex items-center gap-2 flex-shrink-0">
+                    {!quiz.isPublic && (
+                      <span title="Login required" className="text-gray-400">
+                        🔒
+                      </span>
+                    )}
+                    <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-primary-100 text-primary-800">
+                      {quiz.questionCount} questions
+                    </span>
+                  </div>
+                </div>
+                <p className="text-gray-600 mb-4">{quiz.description}</p>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-gray-500">{quiz.category}</span>
+                  {locked ? (
+                    <span className="text-gray-400 text-sm">Login to access</span>
+                  ) : (
+                    <span className="text-primary-600 group-hover:translate-x-1 transition-transform">
+                      Start Quiz →
                     </span>
                   )}
-                  <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-primary-100 text-primary-800">
-                    {quiz.questionCount} questions
-                  </span>
                 </div>
-              </div>
-              <p className="text-gray-600 mb-4">{quiz.description}</p>
-              <div className="flex items-center justify-between">
-                <span className="text-sm text-gray-500">{quiz.category}</span>
-                <span className="text-primary-600 group-hover:translate-x-1 transition-transform">
-                  Start Quiz →
-                </span>
-              </div>
-            </Link>
-          ))}
+              </Link>
+            );
+          })}
         </div>
       )}
     </div>

--- a/frontend/src/pages/QuizResults.tsx
+++ b/frontend/src/pages/QuizResults.tsx
@@ -128,9 +128,7 @@ export default function QuizResults() {
     return reviewWrongOnly ? indexed.filter(({ result }) => !result.isCorrect) : indexed;
   }, [results, reviewWrongOnly]);
 
-  const wrongCount = results
-    ? results.results.length - results.score.correct
-    : 0;
+  const wrongCount = results ? results.results.length - results.score.correct : 0;
 
   if (loading) {
     return (
@@ -253,6 +251,7 @@ export default function QuizResults() {
                   {result.options.map((option, optionIndex) => {
                     const isCorrect = optionIndex === result.correctOption;
                     const isSelected = optionIndex === result.selectedOption;
+                    const label = String.fromCharCode(65 + optionIndex);
 
                     return (
                       <div
@@ -266,7 +265,15 @@ export default function QuizResults() {
                         }`}
                       >
                         <div className="flex items-center justify-between">
-                          <span className="text-gray-900">{option}</span>
+                          <div className="flex items-center">
+                            <span
+                              className="inline-flex items-center justify-center w-6 h-6 mr-3 text-xs font-mono font-semibold text-gray-500 bg-gray-100 rounded"
+                              aria-hidden="true"
+                            >
+                              {label}
+                            </span>
+                            <span className="text-gray-900">{option}</span>
+                          </div>
                           {isCorrect && (
                             <span className="text-sm font-medium text-green-700">
                               Correct Answer

--- a/frontend/src/pages/QuizTake.tsx
+++ b/frontend/src/pages/QuizTake.tsx
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { useAuth0 } from '@auth0/auth0-react';
 import { getQuiz, getQuestions } from '../api/client';
 import type { QuizDetail, Question, Answer } from '../types';
+
+const OPTION_LABELS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
 function formatTime(seconds: number): string {
   const m = Math.floor(seconds / 60);
@@ -12,6 +15,7 @@ function formatTime(seconds: number): string {
 export default function QuizTake() {
   const { quizId } = useParams<{ quizId: string }>();
   const navigate = useNavigate();
+  const { isAuthenticated, loginWithRedirect, isLoading: authLoading } = useAuth0();
 
   const [quiz, setQuiz] = useState<QuizDetail | null>(null);
   const [questions, setQuestions] = useState<Question[]>([]);
@@ -20,6 +24,7 @@ export default function QuizTake() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [secondsLeft, setSecondsLeft] = useState<number | null>(null);
+  const [requiresAuth, setRequiresAuth] = useState(false);
 
   const answersRef = useRef<Answer[]>([]);
   const questionsRef = useRef<Question[]>([]);
@@ -35,13 +40,19 @@ export default function QuizTake() {
 
   useEffect(() => {
     async function loadQuiz() {
-      if (!quizId) return;
+      if (!quizId || authLoading) return;
 
       try {
-        const [quizData, questionsData] = await Promise.all([
-          getQuiz(quizId),
-          getQuestions(quizId),
-        ]);
+        const quizData = await getQuiz(quizId);
+
+        if (!quizData.isPublic && !isAuthenticated) {
+          setQuiz(quizData);
+          setRequiresAuth(true);
+          setLoading(false);
+          return;
+        }
+
+        const questionsData = await getQuestions(quizId);
         setQuiz(quizData);
         setQuestions(questionsData);
         sessionStorage.setItem('quizStartedAt', Date.now().toString());
@@ -56,7 +67,7 @@ export default function QuizTake() {
     }
 
     loadQuiz();
-  }, [quizId]);
+  }, [quizId, isAuthenticated, authLoading]);
 
   const submit = useCallback(
     (auto: boolean) => {
@@ -89,9 +100,7 @@ export default function QuizTake() {
   }, [secondsLeft, submit]);
 
   const currentQuestion = questions[currentIndex];
-  const currentAnswer = answers.find(
-    (a) => a.questionId === currentQuestion?.questionId
-  );
+  const currentAnswer = answers.find((a) => a.questionId === currentQuestion?.questionId);
 
   const handleSelectOption = useCallback(
     (optionIndex: number) => {
@@ -101,9 +110,7 @@ export default function QuizTake() {
         const existing = prev.find((a) => a.questionId === currentQuestion.questionId);
         if (existing) {
           return prev.map((a) =>
-            a.questionId === currentQuestion.questionId
-              ? { ...a, selectedOption: optionIndex }
-              : a
+            a.questionId === currentQuestion.questionId ? { ...a, selectedOption: optionIndex } : a
           );
         }
         return [...prev, { questionId: currentQuestion.questionId, selectedOption: optionIndex }];
@@ -137,8 +144,8 @@ export default function QuizTake() {
       if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
       if (e.metaKey || e.ctrlKey || e.altKey) return;
 
-      if (e.key >= '1' && e.key <= '9') {
-        const idx = parseInt(e.key, 10) - 1;
+      if (e.key >= 'a' && e.key <= 'z') {
+        const idx = e.key.charCodeAt(0) - 97; // a=0, b=1, c=2, d=3
         if (idx < currentQuestion.options.length) {
           e.preventDefault();
           handleSelectOption(idx);
@@ -201,6 +208,28 @@ export default function QuizTake() {
     );
   }
 
+  if (requiresAuth) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="card max-w-md text-center">
+          <div className="text-4xl mb-4">🔒</div>
+          <h2 className="text-xl font-bold text-gray-900 mb-2">{quiz?.title || 'Quiz'}</h2>
+          <p className="text-gray-600 mb-6">
+            This quiz requires you to log in before you can take it.
+          </p>
+          <div className="flex gap-4 justify-center">
+            <button onClick={() => loginWithRedirect()} className="btn-primary">
+              Log In
+            </button>
+            <button onClick={() => navigate('/')} className="btn-secondary">
+              Back to Quizzes
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   if (error || !quiz || !currentQuestion) {
     return (
       <div className="flex items-center justify-center min-h-screen">
@@ -247,9 +276,7 @@ export default function QuizTake() {
       </div>
 
       <div className="card mb-6">
-        <h2 className="text-xl font-semibold text-gray-900 mb-6">
-          {currentQuestion.text}
-        </h2>
+        <h2 className="text-xl font-semibold text-gray-900 mb-6">{currentQuestion.text}</h2>
 
         <div className="space-y-3">
           {currentQuestion.options.map((option, index) => (
@@ -284,7 +311,7 @@ export default function QuizTake() {
                   className="inline-flex items-center justify-center w-6 h-6 mr-3 text-xs font-mono font-semibold text-gray-500 bg-gray-100 rounded"
                   aria-hidden="true"
                 >
-                  {index + 1}
+                  {OPTION_LABELS[index]}
                 </span>
                 <span className="text-gray-900">{option}</span>
               </div>
@@ -294,11 +321,7 @@ export default function QuizTake() {
       </div>
 
       <div className="flex items-center justify-between">
-        <button
-          onClick={handlePrevious}
-          disabled={currentIndex === 0}
-          className="btn-secondary"
-        >
+        <button onClick={handlePrevious} disabled={currentIndex === 0} className="btn-secondary">
           ← Previous
         </button>
 
@@ -307,11 +330,7 @@ export default function QuizTake() {
         </div>
 
         {isLast ? (
-          <button
-            onClick={handleSubmit}
-            disabled={!canSubmit}
-            className="btn-primary"
-          >
+          <button onClick={handleSubmit} disabled={!canSubmit} className="btn-primary">
             Submit Quiz
           </button>
         ) : (
@@ -322,9 +341,15 @@ export default function QuizTake() {
       </div>
 
       <p className="hidden sm:block text-center text-xs text-gray-400 mt-6">
-        Shortcuts: <kbd className="px-1.5 py-0.5 bg-gray-100 border border-gray-200 rounded">1</kbd>–<kbd className="px-1.5 py-0.5 bg-gray-100 border border-gray-200 rounded">{currentQuestion.options.length}</kbd> select
-        · <kbd className="px-1.5 py-0.5 bg-gray-100 border border-gray-200 rounded">←</kbd>/<kbd className="px-1.5 py-0.5 bg-gray-100 border border-gray-200 rounded">→</kbd> nav
-        · <kbd className="px-1.5 py-0.5 bg-gray-100 border border-gray-200 rounded">Enter</kbd> {isLast ? 'submit' : 'next'}
+        Shortcuts: <kbd className="px-1.5 py-0.5 bg-gray-100 border border-gray-200 rounded">A</kbd>
+        –
+        <kbd className="px-1.5 py-0.5 bg-gray-100 border border-gray-200 rounded">
+          {OPTION_LABELS[currentQuestion.options.length - 1]}
+        </kbd>{' '}
+        select · <kbd className="px-1.5 py-0.5 bg-gray-100 border border-gray-200 rounded">←</kbd>/
+        <kbd className="px-1.5 py-0.5 bg-gray-100 border border-gray-200 rounded">→</kbd> nav ·{' '}
+        <kbd className="px-1.5 py-0.5 bg-gray-100 border border-gray-200 rounded">Enter</kbd>{' '}
+        {isLast ? 'submit' : 'next'}
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary

- Block unauthenticated users from taking non-public quizzes (auth gate with login button)
- Fade/darken locked quizzes on home page with 'Login to access' text instead of just a lock emoji
- Change MCQ option labels from 1-4 to A-D in both quiz-taking and results pages
- Update keyboard shortcuts from 1-9 to a-d

## What was tested

- Frontend build passes cleanly
- Prettier ran via lint-staged on commit