### PR TITLE
fix: enforce isPublic access control on backend quiz endpoints

### DIFF
--- a/.infra/modules/backend/main.tf
+++ b/.infra/modules/backend/main.tf
@@ -139,6 +139,7 @@ resource "aws_lambda_function" "get_questions" {
   environment {
     variables = {
       TABLE_NAME = var.dynamodb_table_name
+      AUTH0_DOMAIN = var.auth0_domain
       NODE_ENV   = var.environment
     }
   }
@@ -162,6 +163,7 @@ resource "aws_lambda_function" "submit_answers" {
   environment {
     variables = {
       TABLE_NAME = var.dynamodb_table_name
+      AUTH0_DOMAIN = var.auth0_domain
       NODE_ENV   = var.environment
     }
   }

--- a/backend/src/handlers/getQuestions.ts
+++ b/backend/src/handlers/getQuestions.ts
@@ -1,6 +1,12 @@
 import type { APIGatewayProxyEvent, APIGatewayProxyResult, Question } from '../lib/types.js';
-import { getApprovedQuestionsByJobId, getExtractionJob, shuffleArray, updateQuestionUsage } from '../lib/dynamodb.js';
+import {
+  getApprovedQuestionsByJobId,
+  getExtractionJob,
+  shuffleArray,
+  updateQuestionUsage,
+} from '../lib/dynamodb.js';
 import { successResponse, errorResponse } from '../lib/response.js';
+import { verifyToken } from '../lib/verifyToken.js';
 
 /**
  * GET /quizzes/{id}/questions
@@ -30,6 +36,16 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
     if (!job || !job.published || job.approvedCount === 0) {
       return errorResponse('Quiz not found', 404);
+    }
+
+    // Enforce auth for non-public quizzes
+    if (!job.isPublic) {
+      const userId = await verifyToken(
+        event.headers?.Authorization || event.headers?.authorization
+      );
+      if (!userId) {
+        return errorResponse('Authentication required', 401);
+      }
     }
 
     // Get approved questions for this job, optionally narrowed by the quiz's law filter

--- a/backend/src/handlers/submitAnswers.ts
+++ b/backend/src/handlers/submitAnswers.ts
@@ -1,6 +1,11 @@
-import type { APIGatewayProxyEvent, APIGatewayProxyResult, BankQuestionItem } from '../lib/types.js';
+import type {
+  APIGatewayProxyEvent,
+  APIGatewayProxyResult,
+  BankQuestionItem,
+} from '../lib/types.js';
 import { getExtractionJob, getBankQuestion } from '../lib/dynamodb.js';
 import { successResponse, errorResponse } from '../lib/response.js';
+import { verifyToken } from '../lib/verifyToken.js';
 
 interface SubmitAnswersRequest {
   answers: Array<{
@@ -63,6 +68,16 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
     if (!job || !job.published) {
       return errorResponse('Quiz not found', 404);
+    }
+
+    // Enforce auth for non-public quizzes
+    if (!job.isPublic) {
+      const userId = await verifyToken(
+        event.headers?.Authorization || event.headers?.authorization
+      );
+      if (!userId) {
+        return errorResponse('Authentication required', 401);
+      }
     }
 
     // Fetch each question and build results

--- a/backend/src/lib/verifyToken.ts
+++ b/backend/src/lib/verifyToken.ts
@@ -1,0 +1,49 @@
+import jwt from 'jsonwebtoken';
+import jwksClient from 'jwks-rsa';
+
+const AUTH0_DOMAIN = process.env.AUTH0_DOMAIN;
+
+const client = AUTH0_DOMAIN
+  ? jwksClient({
+      jwksUri: `https://${AUTH0_DOMAIN}/.well-known/jwks.json`,
+      cache: true,
+      cacheMaxAge: 600000,
+    })
+  : null;
+
+function getSigningKey(kid: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    client!.getSigningKey(kid, (err, key) => {
+      if (err) return reject(err);
+      const signingKey = key?.getPublicKey();
+      if (!signingKey) return reject(new Error('Unable to get signing key'));
+      resolve(signingKey);
+    });
+  });
+}
+
+/**
+ * Verify a Bearer token from the Authorization header.
+ * Returns the user's `sub` claim on success, or null if missing/invalid.
+ */
+export async function verifyToken(authHeader: string | undefined): Promise<string | null> {
+  if (!AUTH0_DOMAIN || !client) return null;
+
+  const token = authHeader?.replace(/^Bearer\s+/i, '');
+  if (!token) return null;
+
+  try {
+    const decoded = jwt.decode(token, { complete: true });
+    if (!decoded || typeof decoded === 'string' || !decoded.header.kid) return null;
+
+    const signingKey = await getSigningKey(decoded.header.kid);
+    const verified = jwt.verify(token, signingKey, {
+      issuer: `https://${AUTH0_DOMAIN}/`,
+      algorithms: ['RS256'],
+    }) as { sub: string };
+
+    return verified.sub;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -53,19 +53,28 @@ export async function getQuiz(quizId: string): Promise<QuizDetail> {
   return fetchAPI<QuizDetail>(`/quizzes/${quizId}`);
 }
 
-export async function getQuestions(quizId: string, limit?: number): Promise<Question[]> {
+export async function getQuestions(
+  quizId: string,
+  limit?: number,
+  token?: string
+): Promise<Question[]> {
   const query = limit !== undefined ? `?limit=${limit}` : '';
-  return fetchAPI<Question[]>(`/quizzes/${quizId}/questions${query}`);
+  return fetchAPI<Question[]>(`/quizzes/${quizId}/questions${query}`, undefined, token);
 }
 
 export async function submitAnswers(
   quizId: string,
-  answers: Answer[]
+  answers: Answer[],
+  token?: string
 ): Promise<SubmitAnswersResponse> {
-  return fetchAPI<SubmitAnswersResponse>(`/quizzes/${quizId}/submit`, {
-    method: 'POST',
-    body: JSON.stringify({ answers }),
-  });
+  return fetchAPI<SubmitAnswersResponse>(
+    `/quizzes/${quizId}/submit`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ answers }),
+    },
+    token
+  );
 }
 
 // Admin endpoints (require auth token)

--- a/frontend/src/pages/QuizResults.tsx
+++ b/frontend/src/pages/QuizResults.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { useAuth0 } from '@auth0/auth0-react';
 import { useParams, useNavigate } from 'react-router-dom';
 import confetti from 'canvas-confetti';
 import { submitAnswers } from '../api/client';
@@ -64,6 +65,7 @@ function formatDuration(ms: number): string {
 export default function QuizResults() {
   const { quizId } = useParams<{ quizId: string }>();
   const navigate = useNavigate();
+  const { isAuthenticated, getIdTokenClaims } = useAuth0();
 
   const [results, setResults] = useState<SubmitAnswersResponse | null>(null);
   const [loading, setLoading] = useState(true);
@@ -91,7 +93,12 @@ export default function QuizResults() {
 
       try {
         const answers: Answer[] = JSON.parse(storedAnswers);
-        const response = await submitAnswers(quizId, answers);
+        let token: string | undefined;
+        if (isAuthenticated) {
+          const claims = await getIdTokenClaims();
+          token = claims?.__raw;
+        }
+        const response = await submitAnswers(quizId, answers, token);
         setResults(response);
         triggerConfetti(response.score.percentage);
       } catch (err) {

--- a/frontend/src/pages/QuizTake.tsx
+++ b/frontend/src/pages/QuizTake.tsx
@@ -15,7 +15,12 @@ function formatTime(seconds: number): string {
 export default function QuizTake() {
   const { quizId } = useParams<{ quizId: string }>();
   const navigate = useNavigate();
-  const { isAuthenticated, loginWithRedirect, isLoading: authLoading } = useAuth0();
+  const {
+    isAuthenticated,
+    loginWithRedirect,
+    isLoading: authLoading,
+    getIdTokenClaims,
+  } = useAuth0();
 
   const [quiz, setQuiz] = useState<QuizDetail | null>(null);
   const [questions, setQuestions] = useState<Question[]>([]);
@@ -52,7 +57,12 @@ export default function QuizTake() {
           return;
         }
 
-        const questionsData = await getQuestions(quizId);
+        let token: string | undefined;
+        if (isAuthenticated) {
+          const claims = await getIdTokenClaims();
+          token = claims?.__raw;
+        }
+        const questionsData = await getQuestions(quizId, undefined, token);
         setQuiz(quizData);
         setQuestions(questionsData);
         sessionStorage.setItem('quizStartedAt', Date.now().toString());


### PR DESCRIPTION
## Summary

Closes #50

The `isPublic` flag was only enforced on the frontend. The backend `getQuestions` and `submitAnswers` endpoints were open to unauthenticated access regardless of the quiz's visibility setting.

## Changes

### Backend
- **New**: `backend/src/lib/verifyToken.ts` — lightweight JWT verification utility (reuses `jsonwebtoken` + `jwks-rsa` already in deps)
- **Modified**: `getQuestions` handler — checks `isPublic`; returns 401 if non-public and no valid token
- **Modified**: `submitAnswers` handler — same auth check

### Infrastructure
- Added `AUTH0_DOMAIN` env var to `getQuestions` and `submitAnswers` Lambda functions

### Frontend
- `getQuestions()` and `submitAnswers()` now accept an optional `token` parameter
- `QuizTake` passes the ID token when fetching questions for authenticated users
- `QuizResults` passes the ID token when submitting answers

## What was tested
- Backend builds cleanly
- Frontend builds cleanly
- Public quizzes: no auth needed (unchanged behaviour)
- Non-public quizzes: backend returns 401 without valid JWT