### PR TITLE
feat: shuffle MCQ options on each quiz attempt

### DIFF
--- a/backend/src/handlers/createManualJob.ts
+++ b/backend/src/handlers/createManualJob.ts
@@ -1,12 +1,31 @@
 import { ulid } from 'ulid';
-import type { APIGatewayProxyEvent, APIGatewayProxyResult, ExtractionJobItem, Law } from '../lib/types.js';
+import type {
+  APIGatewayProxyEvent,
+  APIGatewayProxyResult,
+  ExtractionJobItem,
+  Law,
+} from '../lib/types.js';
 import { createExtractionJob } from '../lib/dynamodb.js';
 import { successResponse, errorResponse } from '../lib/response.js';
 
 const VALID_LAWS = new Set<Law>([
-  'Law 1', 'Law 2', 'Law 3', 'Law 4', 'Law 5', 'Law 6', 'Law 7', 'Law 8',
-  'Law 9', 'Law 10', 'Law 11', 'Law 12', 'Law 13', 'Law 14', 'Law 15',
-  'Law 16', 'Law 17',
+  'Law 1',
+  'Law 2',
+  'Law 3',
+  'Law 4',
+  'Law 5',
+  'Law 6',
+  'Law 7',
+  'Law 8',
+  'Law 9',
+  'Law 10',
+  'Law 11',
+  'Law 12',
+  'Law 13',
+  'Law 14',
+  'Law 15',
+  'Law 16',
+  'Law 17',
 ]);
 
 interface CreateManualJobRequest {
@@ -16,6 +35,7 @@ interface CreateManualJobRequest {
   timeLimitMinutes?: number;
   lawFilter?: Law;
   questionsPerAttempt?: number;
+  shuffleOptions?: boolean;
 }
 
 /**
@@ -92,15 +112,21 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
       category: request.category?.trim() || 'Laws of the Game',
       ...(request.timeLimitMinutes !== undefined && { timeLimitMinutes: request.timeLimitMinutes }),
       ...(request.lawFilter !== undefined && { lawFilter: request.lawFilter }),
-      ...(request.questionsPerAttempt !== undefined && { questionsPerAttempt: request.questionsPerAttempt }),
+      ...(request.questionsPerAttempt !== undefined && {
+        questionsPerAttempt: request.questionsPerAttempt,
+      }),
+      ...(request.shuffleOptions !== undefined && { shuffleOptions: request.shuffleOptions }),
     };
 
     await createExtractionJob(job);
 
-    return successResponse({
-      jobId,
-      message: 'Manual job created successfully',
-    }, 201);
+    return successResponse(
+      {
+        jobId,
+        message: 'Manual job created successfully',
+      },
+      201
+    );
   } catch (error) {
     console.error('Error creating manual job:', error);
     return errorResponse('Failed to create manual job', 500);

--- a/backend/src/handlers/getQuiz.ts
+++ b/backend/src/handlers/getQuiz.ts
@@ -49,7 +49,10 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
       updatedAt: job.updatedAt,
       ...(job.timeLimitMinutes !== undefined && { timeLimitMinutes: job.timeLimitMinutes }),
       ...(job.lawFilter !== undefined && { lawFilter: job.lawFilter }),
-      ...(job.questionsPerAttempt !== undefined && { questionsPerAttempt: job.questionsPerAttempt }),
+      ...(job.questionsPerAttempt !== undefined && {
+        questionsPerAttempt: job.questionsPerAttempt,
+      }),
+      ...(job.shuffleOptions !== undefined && { shuffleOptions: job.shuffleOptions }),
     };
 
     return successResponse(detail);

--- a/backend/src/handlers/getQuizzes.ts
+++ b/backend/src/handlers/getQuizzes.ts
@@ -36,6 +36,7 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
       ...(job.questionsPerAttempt !== undefined && {
         questionsPerAttempt: job.questionsPerAttempt,
       }),
+      ...(job.shuffleOptions !== undefined && { shuffleOptions: job.shuffleOptions }),
     }));
 
     return successResponse(summaries);

--- a/backend/src/lib/types.ts
+++ b/backend/src/lib/types.ts
@@ -110,6 +110,7 @@ export interface ExtractionJobItem {
   timeLimitMinutes?: number;
   lawFilter?: Law;
   questionsPerAttempt?: number;
+  shuffleOptions?: boolean;
 }
 
 // API response types
@@ -123,6 +124,7 @@ export interface QuizSummary {
   timeLimitMinutes?: number;
   lawFilter?: Law;
   questionsPerAttempt?: number;
+  shuffleOptions?: boolean;
 }
 
 export interface QuizDetail extends QuizSummary {

--- a/frontend/src/pages/QuizTake.tsx
+++ b/frontend/src/pages/QuizTake.tsx
@@ -1,10 +1,33 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
 import { getQuiz, getQuestions } from '../api/client';
 import type { QuizDetail, Question, Answer } from '../types';
 
 const OPTION_LABELS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+/** Fisher-Yates shuffle returning a new array */
+function shuffleArray<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+/**
+ * For each question, build a shuffled index order.
+ * shuffleMap[questionId][displayIndex] = originalIndex
+ */
+function buildShuffleMap(questions: Question[]): Record<string, number[]> {
+  const map: Record<string, number[]> = {};
+  for (const q of questions) {
+    const indices = q.options.map((_, i) => i);
+    map[q.questionId] = shuffleArray(indices);
+  }
+  return map;
+}
 
 function formatTime(seconds: number): string {
   const m = Math.floor(seconds / 60);
@@ -19,6 +42,7 @@ export default function QuizTake() {
 
   const [quiz, setQuiz] = useState<QuizDetail | null>(null);
   const [questions, setQuestions] = useState<Question[]>([]);
+  const [shuffleMap, setShuffleMap] = useState<Record<string, number[]>>({});
   const [answers, setAnswers] = useState<Answer[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -55,6 +79,8 @@ export default function QuizTake() {
         const questionsData = await getQuestions(quizId);
         setQuiz(quizData);
         setQuestions(questionsData);
+        const shouldShuffle = quizData.shuffleOptions !== false;
+        setShuffleMap(shouldShuffle ? buildShuffleMap(questionsData) : {});
         sessionStorage.setItem('quizStartedAt', Date.now().toString());
         if (quizData.timeLimitMinutes && quizData.timeLimitMinutes > 0) {
           setSecondsLeft(quizData.timeLimitMinutes * 60);
@@ -102,21 +128,32 @@ export default function QuizTake() {
   const currentQuestion = questions[currentIndex];
   const currentAnswer = answers.find((a) => a.questionId === currentQuestion?.questionId);
 
+  const currentShuffledOptions = useMemo(() => {
+    if (!currentQuestion) return [];
+    const order = shuffleMap[currentQuestion.questionId];
+    if (!order) return currentQuestion.options;
+    return order.map((origIdx) => currentQuestion.options[origIdx]);
+  }, [currentQuestion, shuffleMap]);
+
   const handleSelectOption = useCallback(
-    (optionIndex: number) => {
+    (displayIndex: number) => {
       if (!currentQuestion) return;
+      const order = shuffleMap[currentQuestion.questionId];
+      const originalIndex = order ? order[displayIndex] : displayIndex;
 
       setAnswers((prev) => {
         const existing = prev.find((a) => a.questionId === currentQuestion.questionId);
         if (existing) {
           return prev.map((a) =>
-            a.questionId === currentQuestion.questionId ? { ...a, selectedOption: optionIndex } : a
+            a.questionId === currentQuestion.questionId
+              ? { ...a, selectedOption: originalIndex }
+              : a
           );
         }
-        return [...prev, { questionId: currentQuestion.questionId, selectedOption: optionIndex }];
+        return [...prev, { questionId: currentQuestion.questionId, selectedOption: originalIndex }];
       });
     },
-    [currentQuestion]
+    [currentQuestion, shuffleMap]
   );
 
   const handleNext = useCallback(() => {
@@ -279,44 +316,47 @@ export default function QuizTake() {
         <h2 className="text-xl font-semibold text-gray-900 mb-6">{currentQuestion.text}</h2>
 
         <div className="space-y-3">
-          {currentQuestion.options.map((option, index) => (
-            <button
-              key={index}
-              onClick={() => handleSelectOption(index)}
-              className={`w-full text-left p-4 rounded-lg border-2 transition-all ${
-                currentAnswer?.selectedOption === index
-                  ? 'border-primary-600 bg-primary-50'
-                  : 'border-gray-200 hover:border-gray-300 bg-white'
-              }`}
-            >
-              <div className="flex items-center">
-                <div
-                  className={`flex-shrink-0 w-6 h-6 rounded-full border-2 mr-3 flex items-center justify-center ${
-                    currentAnswer?.selectedOption === index
-                      ? 'border-primary-600 bg-primary-600'
-                      : 'border-gray-300'
-                  }`}
-                >
-                  {currentAnswer?.selectedOption === index && (
-                    <svg className="w-4 h-4 text-white" fill="currentColor" viewBox="0 0 20 20">
-                      <path
-                        fillRule="evenodd"
-                        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                  )}
+          {currentShuffledOptions.map((option, displayIndex) => {
+            const originalIndex =
+              shuffleMap[currentQuestion.questionId]?.[displayIndex] ?? displayIndex;
+            const isSelected = currentAnswer?.selectedOption === originalIndex;
+            return (
+              <button
+                key={displayIndex}
+                onClick={() => handleSelectOption(displayIndex)}
+                className={`w-full text-left p-4 rounded-lg border-2 transition-all ${
+                  isSelected
+                    ? 'border-primary-600 bg-primary-50'
+                    : 'border-gray-200 hover:border-gray-300 bg-white'
+                }`}
+              >
+                <div className="flex items-center">
+                  <div
+                    className={`flex-shrink-0 w-6 h-6 rounded-full border-2 mr-3 flex items-center justify-center ${
+                      isSelected ? 'border-primary-600 bg-primary-600' : 'border-gray-300'
+                    }`}
+                  >
+                    {isSelected && (
+                      <svg className="w-4 h-4 text-white" fill="currentColor" viewBox="0 0 20 20">
+                        <path
+                          fillRule="evenodd"
+                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                          clipRule="evenodd"
+                        />
+                      </svg>
+                    )}
+                  </div>
+                  <span
+                    className="inline-flex items-center justify-center w-6 h-6 mr-3 text-xs font-mono font-semibold text-gray-500 bg-gray-100 rounded"
+                    aria-hidden="true"
+                  >
+                    {OPTION_LABELS[displayIndex]}
+                  </span>
+                  <span className="text-gray-900">{option}</span>
                 </div>
-                <span
-                  className="inline-flex items-center justify-center w-6 h-6 mr-3 text-xs font-mono font-semibold text-gray-500 bg-gray-100 rounded"
-                  aria-hidden="true"
-                >
-                  {OPTION_LABELS[index]}
-                </span>
-                <span className="text-gray-900">{option}</span>
-              </div>
-            </button>
-          ))}
+              </button>
+            );
+          })}
         </div>
       </div>
 

--- a/frontend/src/pages/admin/CreateQuiz.tsx
+++ b/frontend/src/pages/admin/CreateQuiz.tsx
@@ -44,6 +44,7 @@ export default function CreateQuiz() {
   const [timeLimit, setTimeLimit] = useState('');
   const [lawFilter, setLawFilter] = useState<'' | Law>('');
   const [questionsPerAttempt, setQuestionsPerAttempt] = useState('');
+  const [shuffleOptions, setShuffleOptions] = useState(true);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -112,6 +113,7 @@ export default function CreateQuiz() {
           timeLimitMinutes,
           lawFilter: lawFilter || undefined,
           questionsPerAttempt: questionsPerAttemptNum,
+          shuffleOptions,
         },
         token
       );
@@ -386,6 +388,22 @@ export default function CreateQuiz() {
                     </option>
                   ))}
                 </select>
+              </div>
+              <div className="sm:col-span-2">
+                <label className="inline-flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={shuffleOptions}
+                    onChange={(e) => setShuffleOptions(e.target.checked)}
+                    className="w-4 h-4 text-primary-600 rounded border-gray-300 focus:ring-primary-500"
+                    disabled={loading}
+                  />
+                  <span className="text-sm font-medium text-gray-700">Shuffle answer options</span>
+                </label>
+                <p className="text-xs text-gray-500 mt-1 ml-6">
+                  Randomise the order of answer options on each attempt. Disable for quizzes where
+                  option order matters.
+                </p>
               </div>
             </div>
           </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -8,6 +8,7 @@ export interface QuizSummary {
   timeLimitMinutes?: number;
   lawFilter?: Law;
   questionsPerAttempt?: number;
+  shuffleOptions?: boolean;
 }
 
 export interface QuizDetail extends QuizSummary {
@@ -107,6 +108,7 @@ export interface ExtractionJob {
   timeLimitMinutes?: number;
   lawFilter?: Law;
   questionsPerAttempt?: number;
+  shuffleOptions?: boolean;
 }
 
 export interface PresignedUrlResponse {
@@ -172,6 +174,7 @@ export interface CreateManualJobRequest {
   timeLimitMinutes?: number;
   lawFilter?: Law;
   questionsPerAttempt?: number;
+  shuffleOptions?: boolean;
 }
 
 export interface CreateManualJobResponse {


### PR DESCRIPTION
## Summary

Closes #49

Options for each question are now shuffled on every quiz load, preventing users from memorising answer positions. This is especially important for exam scenarios where people might share "option A" or "option B" answers.

## Admin Control

A new **Shuffle answer options** checkbox is available in the Create Quiz form (under Quiz Configuration). It defaults to **on** but can be disabled for quizzes where fixed option order is preferred — e.g. quick mini quizzes where you want to iterate fast.

The `shuffleOptions` flag is stored on the quiz and returned by the API. Existing quizzes without the flag default to shuffled (`shuffleOptions !== false`).

## How it works

- When questions load, a `shuffleMap` is built per question: `shuffleMap[questionId][displayIndex] = originalIndex`
- Options render in shuffled order using the map
- When the user selects an option, the display index is mapped back to the original index before storing
- The `selectedOption` in answers always uses original indices, so backend grading works unchanged
- The shuffle is stable within an attempt (navigating back shows the same order) but different on retake
- If `shuffleOptions` is `false`, no shuffle map is built and options display in their original order

## Files Changed

### Backend
- `types.ts` — added `shuffleOptions?: boolean` to `ExtractionJobItem` and `QuizSummary`
- `createManualJob.ts` — accepts and stores `shuffleOptions`
- `getQuizzes.ts` / `getQuiz.ts` — returns `shuffleOptions` in quiz response

### Frontend
- `types/index.ts` — added `shuffleOptions` to relevant types
- `CreateQuiz.tsx` — checkbox in quiz config section
- `QuizTake.tsx` — shuffle logic with Fisher-Yates, respects the flag

## What was tested
- Backend and frontend build cleanly
- Keyboard shortcuts (A-D) work with shuffled options