### PR TITLE
fix: return isPublic flag from getQuiz endpoint

### DIFF
--- a/backend/src/handlers/getQuiz.ts
+++ b/backend/src/handlers/getQuiz.ts
@@ -45,6 +45,7 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
       description: job.description?.trim() || `Questions extracted from ${job.fileName}`,
       category: job.category || 'Laws of the Game',
       questionCount: job.approvedCount,
+      isPublic: job.isPublic ?? false,
       createdAt: job.createdAt,
       updatedAt: job.updatedAt,
       ...(job.timeLimitMinutes !== undefined && { timeLimitMinutes: job.timeLimitMinutes }),


### PR DESCRIPTION
## Problem

The `GET /quizzes/{id}` endpoint was not returning the `isPublic` field in the response. The quiz list endpoint (`GET /quizzes`) returned it correctly (`isPublic: job.isPublic ?? false`), but the individual quiz endpoint omitted it.

This caused the frontend `QuizTake` page to always see `isPublic` as `undefined` (falsy), showing the login gate for **every** quiz — including ones that should be public.

## Fix

One-line addition: include `isPublic: job.isPublic ?? false` in the `getQuiz` response, matching the pattern already used in `getQuizzes`.

## What was tested
- Backend builds cleanly