### PR TITLE
feat(admin): add Manage Quizzes section

### DIFF
--- a/.infra/modules/backend/main.tf
+++ b/.infra/modules/backend/main.tf
@@ -17,6 +17,8 @@ locals {
     "getExtractionJobs",
     "createManualJob",
     "addManualQuestion",
+    "updateJobMetadata",
+    "removeJobQuestion",
     "authorize",
   ]
 }
@@ -427,6 +429,8 @@ resource "aws_api_gateway_deployment" "this" {
     aws_api_gateway_integration.publish_quiz,
     aws_api_gateway_integration.create_manual_job,
     aws_api_gateway_integration.add_manual_question,
+    aws_api_gateway_integration.update_job_metadata,
+    aws_api_gateway_integration.remove_job_question,
   ]
 
   lifecycle {
@@ -452,6 +456,8 @@ resource "aws_api_gateway_deployment" "this" {
       aws_api_gateway_resource.admin_bulk_review.id,
       aws_api_gateway_resource.admin_jobs_manual.id,
       aws_api_gateway_resource.admin_job_questions.id,
+      aws_api_gateway_resource.admin_job_metadata.id,
+      aws_api_gateway_resource.admin_job_question_id.id,
       [for r in aws_api_gateway_gateway_response.cors : r.id],
     ]))
   }
@@ -1270,6 +1276,142 @@ resource "aws_lambda_permission" "add_manual_question" {
   statement_id  = "AllowAPIGatewayInvoke"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.add_manual_question.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
+}
+
+# ============================================================================
+# Lambda Function: updateJobMetadata
+# ============================================================================
+
+resource "aws_lambda_function" "update_job_metadata" {
+  filename         = "${path.module}/../../../backend/dist/updateJobMetadata.zip"
+  function_name    = "${var.project_name}-${var.environment}-updateJobMetadata"
+  role             = aws_iam_role.lambda_admin.arn
+  handler          = "index.handler"
+  runtime          = "nodejs24.x"
+  timeout          = 10
+  memory_size      = 256
+  source_code_hash = fileexists("${path.module}/../../../backend/dist/updateJobMetadata.zip") ? filebase64sha256("${path.module}/../../../backend/dist/updateJobMetadata.zip") : null
+
+  environment {
+    variables = {
+      TABLE_NAME = var.dynamodb_table_name
+      NODE_ENV   = var.environment
+    }
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-updateJobMetadata"
+  }
+}
+
+# ============================================================================
+# Lambda Function: removeJobQuestion
+# ============================================================================
+
+resource "aws_lambda_function" "remove_job_question" {
+  filename         = "${path.module}/../../../backend/dist/removeJobQuestion.zip"
+  function_name    = "${var.project_name}-${var.environment}-removeJobQuestion"
+  role             = aws_iam_role.lambda_admin.arn
+  handler          = "index.handler"
+  runtime          = "nodejs24.x"
+  timeout          = 10
+  memory_size      = 256
+  source_code_hash = fileexists("${path.module}/../../../backend/dist/removeJobQuestion.zip") ? filebase64sha256("${path.module}/../../../backend/dist/removeJobQuestion.zip") : null
+
+  environment {
+    variables = {
+      TABLE_NAME = var.dynamodb_table_name
+      NODE_ENV   = var.environment
+    }
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-removeJobQuestion"
+  }
+}
+
+# /admin/jobs/{id}/metadata resource
+resource "aws_api_gateway_resource" "admin_job_metadata" {
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  parent_id   = aws_api_gateway_resource.admin_job_id.id
+  path_part   = "metadata"
+}
+
+# PUT /admin/jobs/{id}/metadata
+resource "aws_api_gateway_method" "update_job_metadata" {
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  resource_id   = aws_api_gateway_resource.admin_job_metadata.id
+  http_method   = "PUT"
+  authorization = "CUSTOM"
+  authorizer_id = aws_api_gateway_authorizer.jwt.id
+}
+
+resource "aws_api_gateway_integration" "update_job_metadata" {
+  rest_api_id             = aws_api_gateway_rest_api.this.id
+  resource_id             = aws_api_gateway_resource.admin_job_metadata.id
+  http_method             = aws_api_gateway_method.update_job_metadata.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.update_job_metadata.invoke_arn
+}
+
+# /admin/jobs/{id}/questions/{questionId} resource
+resource "aws_api_gateway_resource" "admin_job_question_id" {
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  parent_id   = aws_api_gateway_resource.admin_job_questions.id
+  path_part   = "{questionId}"
+}
+
+# DELETE /admin/jobs/{id}/questions/{questionId}
+resource "aws_api_gateway_method" "remove_job_question" {
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  resource_id   = aws_api_gateway_resource.admin_job_question_id.id
+  http_method   = "DELETE"
+  authorization = "CUSTOM"
+  authorizer_id = aws_api_gateway_authorizer.jwt.id
+}
+
+resource "aws_api_gateway_integration" "remove_job_question" {
+  rest_api_id             = aws_api_gateway_rest_api.this.id
+  resource_id             = aws_api_gateway_resource.admin_job_question_id.id
+  http_method             = aws_api_gateway_method.remove_job_question.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.remove_job_question.invoke_arn
+}
+
+# CORS for new routes
+module "cors_admin_job_metadata" {
+  source  = "squidfunk/api-gateway-enable-cors/aws"
+  version = "0.3.3"
+
+  api_id          = aws_api_gateway_rest_api.this.id
+  api_resource_id = aws_api_gateway_resource.admin_job_metadata.id
+}
+
+module "cors_admin_job_question_id" {
+  source  = "squidfunk/api-gateway-enable-cors/aws"
+  version = "0.3.3"
+
+  api_id          = aws_api_gateway_rest_api.this.id
+  api_resource_id = aws_api_gateway_resource.admin_job_question_id.id
+}
+
+# Lambda permissions
+resource "aws_lambda_permission" "update_job_metadata" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.update_job_metadata.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
+}
+
+resource "aws_lambda_permission" "remove_job_question" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.remove_job_question.function_name
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
 }

--- a/.infra/modules/backend/outputs.tf
+++ b/.infra/modules/backend/outputs.tf
@@ -29,6 +29,8 @@ output "lambda_function_names" {
     publish_quiz           = aws_lambda_function.publish_quiz.function_name
     create_manual_job      = aws_lambda_function.create_manual_job.function_name
     add_manual_question    = aws_lambda_function.add_manual_question.function_name
+    update_job_metadata    = aws_lambda_function.update_job_metadata.function_name
+    remove_job_question    = aws_lambda_function.remove_job_question.function_name
     authorize              = aws_lambda_function.authorize.function_name
   }
 }
@@ -49,6 +51,8 @@ output "lambda_function_arns" {
     publish_quiz           = aws_lambda_function.publish_quiz.arn
     create_manual_job      = aws_lambda_function.create_manual_job.arn
     add_manual_question    = aws_lambda_function.add_manual_question.arn
+    update_job_metadata    = aws_lambda_function.update_job_metadata.arn
+    remove_job_question    = aws_lambda_function.remove_job_question.arn
     authorize              = aws_lambda_function.authorize.arn
   }
 }

--- a/backend/build.js
+++ b/backend/build.js
@@ -26,6 +26,9 @@ const handlers = [
   // Manual quiz creation handlers
   'createManualJob',
   'addManualQuestion',
+  // Quiz management handlers
+  'updateJobMetadata',
+  'removeJobQuestion',
   // Auth
   'authorize',
 ];

--- a/backend/src/handlers/removeJobQuestion.ts
+++ b/backend/src/handlers/removeJobQuestion.ts
@@ -1,0 +1,41 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from '../lib/types.js';
+import {
+  getBankQuestion,
+  updateBankQuestionStatus,
+  updateExtractionJob,
+  getExtractionJob,
+} from '../lib/dynamodb.js';
+import { successResponse, errorResponse } from '../lib/response.js';
+
+export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  const jobId = event.pathParameters?.id;
+  const questionId = event.pathParameters?.questionId;
+
+  if (!jobId || !questionId) return errorResponse('Missing job ID or question ID', 400);
+
+  try {
+    const question = await getBankQuestion(questionId);
+    if (!question) return errorResponse('Question not found', 404);
+    if (question.jobId !== jobId) return errorResponse('Question does not belong to this job', 400);
+    if (question.status !== 'approved') return errorResponse('Question is not approved', 400);
+
+    const job = await getExtractionJob(jobId);
+    if (!job) return errorResponse('Job not found', 404);
+
+    await updateBankQuestionStatus(questionId, 'rejected');
+    await updateExtractionJob(jobId, {
+      approvedCount: Math.max(0, job.approvedCount - 1),
+      rejectedCount: job.rejectedCount + 1,
+      updatedAt: new Date().toISOString(),
+    } as any);
+
+    return successResponse({
+      questionId,
+      message: 'Question removed from quiz',
+      approvedCount: Math.max(0, job.approvedCount - 1),
+    });
+  } catch (error) {
+    console.error('Error removing question:', error);
+    return errorResponse('Failed to remove question', 500);
+  }
+}

--- a/backend/src/handlers/updateJobMetadata.ts
+++ b/backend/src/handlers/updateJobMetadata.ts
@@ -1,0 +1,101 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult, Law } from '../lib/types.js';
+import { getExtractionJob, updateExtractionJob } from '../lib/dynamodb.js';
+import { successResponse, errorResponse } from '../lib/response.js';
+
+const VALID_LAWS = new Set<Law>([
+  'Law 1',
+  'Law 2',
+  'Law 3',
+  'Law 4',
+  'Law 5',
+  'Law 6',
+  'Law 7',
+  'Law 8',
+  'Law 9',
+  'Law 10',
+  'Law 11',
+  'Law 12',
+  'Law 13',
+  'Law 14',
+  'Law 15',
+  'Law 16',
+  'Law 17',
+]);
+
+interface UpdateMetadataRequest {
+  title?: string;
+  description?: string;
+  category?: string;
+  timeLimitMinutes?: number | null;
+  questionsPerAttempt?: number | null;
+  lawFilter?: Law | null;
+  shuffleOptions?: boolean;
+  isPublic?: boolean;
+}
+
+export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  const jobId = event.pathParameters?.id;
+  if (!jobId) return errorResponse('Missing job ID', 400);
+  if (!event.body) return errorResponse('Request body is required', 400);
+
+  let request: UpdateMetadataRequest;
+  try {
+    request = JSON.parse(event.body);
+  } catch {
+    return errorResponse('Invalid JSON body', 400);
+  }
+
+  if (request.timeLimitMinutes !== undefined && request.timeLimitMinutes !== null) {
+    if (
+      typeof request.timeLimitMinutes !== 'number' ||
+      !Number.isFinite(request.timeLimitMinutes) ||
+      request.timeLimitMinutes < 1 ||
+      request.timeLimitMinutes > 240
+    ) {
+      return errorResponse('timeLimitMinutes must be between 1 and 240', 400);
+    }
+  }
+
+  if (request.questionsPerAttempt !== undefined && request.questionsPerAttempt !== null) {
+    if (
+      typeof request.questionsPerAttempt !== 'number' ||
+      !Number.isInteger(request.questionsPerAttempt) ||
+      request.questionsPerAttempt < 1 ||
+      request.questionsPerAttempt > 50
+    ) {
+      return errorResponse('questionsPerAttempt must be an integer between 1 and 50', 400);
+    }
+  }
+
+  if (
+    request.lawFilter !== undefined &&
+    request.lawFilter !== null &&
+    !VALID_LAWS.has(request.lawFilter)
+  ) {
+    return errorResponse('lawFilter must be a valid Law (e.g. "Law 12")', 400);
+  }
+
+  try {
+    const job = await getExtractionJob(jobId);
+    if (!job) return errorResponse('Job not found', 404);
+
+    const updates: Record<string, unknown> = { updatedAt: new Date().toISOString() };
+
+    if (request.title !== undefined) updates.fileName = request.title.trim();
+    if (request.description !== undefined) updates.description = request.description.trim();
+    if (request.category !== undefined) updates.category = request.category.trim();
+    if (request.timeLimitMinutes !== undefined) updates.timeLimitMinutes = request.timeLimitMinutes;
+    if (request.questionsPerAttempt !== undefined)
+      updates.questionsPerAttempt = request.questionsPerAttempt;
+    if (request.lawFilter !== undefined) updates.lawFilter = request.lawFilter;
+    if (request.shuffleOptions !== undefined) updates.shuffleOptions = request.shuffleOptions;
+    if (request.isPublic !== undefined) updates.isPublic = request.isPublic;
+
+    await updateExtractionJob(jobId, updates as any);
+
+    return successResponse({ jobId, message: 'Metadata updated successfully' });
+  } catch (error) {
+    console.error('Error updating job metadata:', error);
+    return errorResponse('Failed to update metadata', 500);
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,9 @@ import AdminReview from './pages/admin/Review';
 import AdminQuestionBank from './pages/admin/QuestionBank';
 import AdminCreateQuiz from './pages/admin/CreateQuiz';
 import AdminAddQuestion from './pages/admin/AddQuestion';
+import AdminManageQuizzes from './pages/admin/ManageQuizzes';
+import AdminEditQuiz from './pages/admin/EditQuiz';
+import AdminQuizQuestions from './pages/admin/QuizQuestions';
 
 export default function App() {
   return (
@@ -34,6 +37,9 @@ export default function App() {
         }
       >
         <Route index element={<AdminDashboard />} />
+        <Route path="quizzes" element={<AdminManageQuizzes />} />
+        <Route path="quizzes/:jobId" element={<AdminQuizQuestions />} />
+        <Route path="quizzes/:jobId/edit" element={<AdminEditQuiz />} />
         <Route path="upload" element={<AdminUpload />} />
         <Route path="create" element={<AdminCreateQuiz />} />
         <Route path="jobs" element={<AdminJobs />} />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -17,6 +17,7 @@ import type {
   AddManualQuestionRequest,
   AddManualQuestionResponse,
   SubmitAnswersResponse,
+  UpdateQuizMetadataRequest,
 } from '../types';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
@@ -233,4 +234,24 @@ export async function addManualQuestion(
     },
     token
   );
+}
+
+export async function updateQuizMetadata(
+  jobId: string,
+  updates: UpdateQuizMetadataRequest,
+  token: string
+): Promise<{ jobId: string; message: string }> {
+  return fetchAPI(
+    `/admin/jobs/${jobId}/metadata`,
+    { method: 'PUT', body: JSON.stringify(updates) },
+    token
+  );
+}
+
+export async function removeQuizQuestion(
+  jobId: string,
+  questionId: string,
+  token: string
+): Promise<{ questionId: string; message: string; approvedCount: number }> {
+  return fetchAPI(`/admin/jobs/${jobId}/questions/${questionId}`, { method: 'DELETE' }, token);
 }

--- a/frontend/src/components/AdminLayout.tsx
+++ b/frontend/src/components/AdminLayout.tsx
@@ -3,6 +3,7 @@ import { useAuth0 } from '@auth0/auth0-react';
 
 const navItems = [
   { to: '/admin', label: 'Dashboard', end: true },
+  { to: '/admin/quizzes', label: 'Quizzes' },
   { to: '/admin/upload', label: 'Upload PDF' },
   { to: '/admin/jobs', label: 'Jobs' },
   { to: '/admin/review', label: 'Review Queue' },

--- a/frontend/src/pages/admin/EditQuiz.tsx
+++ b/frontend/src/pages/admin/EditQuiz.tsx
@@ -1,0 +1,318 @@
+import { useEffect, useState } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { getExtractionJob, updateQuizMetadata } from '../../api/client';
+import { useAccessToken } from '../../hooks/useAccessToken';
+import type { ExtractionJob, Law } from '../../types';
+
+const CATEGORIES = [
+  'Laws of the Game',
+  'Practical Refereeing',
+  'Offside',
+  'Fouls and Misconduct',
+  'Set Pieces',
+  'General Knowledge',
+];
+
+const LAWS: Law[] = [
+  'Law 1',
+  'Law 2',
+  'Law 3',
+  'Law 4',
+  'Law 5',
+  'Law 6',
+  'Law 7',
+  'Law 8',
+  'Law 9',
+  'Law 10',
+  'Law 11',
+  'Law 12',
+  'Law 13',
+  'Law 14',
+  'Law 15',
+  'Law 16',
+  'Law 17',
+];
+
+function formatTitle(fileName: string): string {
+  return fileName
+    .replace(/\.pdf$/i, '')
+    .replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export default function EditQuiz() {
+  const { jobId } = useParams<{ jobId: string }>();
+  const navigate = useNavigate();
+  const { getToken } = useAccessToken();
+
+  const [job, setJob] = useState<ExtractionJob | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [category, setCategory] = useState('Laws of the Game');
+  const [timeLimit, setTimeLimit] = useState('');
+  const [questionsPerAttempt, setQuestionsPerAttempt] = useState('');
+  const [lawFilter, setLawFilter] = useState<'' | Law>('');
+  const [shuffleOptions, setShuffleOptions] = useState(true);
+  const [isPublic, setIsPublic] = useState(false);
+
+  useEffect(() => {
+    if (!jobId) return;
+    getToken()
+      .then((token) => getExtractionJob(jobId, token))
+      .then((data) => {
+        setJob(data);
+        setTitle(formatTitle(data.fileName));
+        setDescription(data.description || '');
+        setCategory(data.category || 'Laws of the Game');
+        setTimeLimit(data.timeLimitMinutes?.toString() || '');
+        setQuestionsPerAttempt(data.questionsPerAttempt?.toString() || '');
+        setLawFilter((data.lawFilter as '' | Law) || '');
+        setShuffleOptions(data.shuffleOptions !== false);
+        setIsPublic(data.isPublic ?? false);
+      })
+      .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load quiz'))
+      .finally(() => setLoading(false));
+  }, [jobId, getToken]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!jobId || !title.trim()) {
+      setError('Title is required');
+      return;
+    }
+
+    let timeLimitNum: number | null = null;
+    if (timeLimit.trim()) {
+      const parsed = Number(timeLimit);
+      if (!Number.isFinite(parsed) || parsed < 1 || parsed > 240) {
+        setError('Time limit must be between 1 and 240');
+        return;
+      }
+      timeLimitNum = parsed;
+    }
+
+    let questionsNum: number | null = null;
+    if (questionsPerAttempt.trim()) {
+      const parsed = Number(questionsPerAttempt);
+      if (!Number.isInteger(parsed) || parsed < 1 || parsed > 50) {
+        setError('Questions per attempt must be 1-50');
+        return;
+      }
+      questionsNum = parsed;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      const token = await getToken();
+      await updateQuizMetadata(
+        jobId,
+        {
+          title: title.trim(),
+          description: description.trim(),
+          category,
+          timeLimitMinutes: timeLimitNum,
+          questionsPerAttempt: questionsNum,
+          lawFilter: lawFilter || null,
+          shuffleOptions,
+          isPublic,
+        },
+        token
+      );
+      navigate('/admin/quizzes');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+      </div>
+    );
+  }
+
+  if (!job) {
+    return (
+      <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
+        <p className="text-red-700">{error || 'Quiz not found'}</p>
+        <Link to="/admin/quizzes" className="mt-4 inline-block btn-secondary">
+          Back
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-8">
+        <Link
+          to="/admin/quizzes"
+          className="text-sm text-gray-500 hover:text-gray-700 mb-2 inline-block"
+        >
+          ← Back to Quizzes
+        </Link>
+        <h1 className="text-2xl font-bold text-gray-900">Edit Quiz</h1>
+      </div>
+
+      <div className="bg-white rounded-lg shadow p-6 max-w-2xl">
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {error && (
+            <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+              <p className="text-red-700">{error}</p>
+            </div>
+          )}
+
+          <div>
+            <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-1">
+              Title *
+            </label>
+            <input
+              type="text"
+              id="title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              disabled={saving}
+            />
+          </div>
+
+          <div>
+            <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-1">
+              Description
+            </label>
+            <textarea
+              id="description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={3}
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              disabled={saving}
+            />
+          </div>
+
+          <div>
+            <label htmlFor="category" className="block text-sm font-medium text-gray-700 mb-1">
+              Category
+            </label>
+            <select
+              id="category"
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              disabled={saving}
+            >
+              {CATEGORIES.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="border-t pt-6">
+            <h2 className="text-sm font-semibold text-gray-900 mb-4">Quiz Configuration</h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="timeLimit" className="block text-sm font-medium text-gray-700 mb-1">
+                  Time Limit (minutes)
+                </label>
+                <input
+                  type="number"
+                  id="timeLimit"
+                  min={1}
+                  max={240}
+                  value={timeLimit}
+                  onChange={(e) => setTimeLimit(e.target.value)}
+                  placeholder="No limit"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                  disabled={saving}
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="questionsPerAttempt"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
+                  Questions per Attempt
+                </label>
+                <input
+                  type="number"
+                  id="questionsPerAttempt"
+                  min={1}
+                  max={50}
+                  value={questionsPerAttempt}
+                  onChange={(e) => setQuestionsPerAttempt(e.target.value)}
+                  placeholder="Default: 10"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                  disabled={saving}
+                />
+              </div>
+              <div className="sm:col-span-2">
+                <label htmlFor="lawFilter" className="block text-sm font-medium text-gray-700 mb-1">
+                  Restrict to a Single Law
+                </label>
+                <select
+                  id="lawFilter"
+                  value={lawFilter}
+                  onChange={(e) => setLawFilter(e.target.value as '' | Law)}
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                  disabled={saving}
+                >
+                  <option value="">All laws</option>
+                  {LAWS.map((l) => (
+                    <option key={l} value={l}>
+                      {l}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="inline-flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={shuffleOptions}
+                    onChange={(e) => setShuffleOptions(e.target.checked)}
+                    className="w-4 h-4 text-primary-600 rounded border-gray-300 focus:ring-primary-500"
+                    disabled={saving}
+                  />
+                  <span className="text-sm font-medium text-gray-700">Shuffle answer options</span>
+                </label>
+              </div>
+              <div>
+                <label className="inline-flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={isPublic}
+                    onChange={(e) => setIsPublic(e.target.checked)}
+                    className="w-4 h-4 text-primary-600 rounded border-gray-300 focus:ring-primary-500"
+                    disabled={saving}
+                  />
+                  <span className="text-sm font-medium text-gray-700">
+                    Public (no login required)
+                  </span>
+                </label>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex gap-4">
+            <button type="submit" disabled={saving} className="btn-primary disabled:opacity-50">
+              {saving ? 'Saving...' : 'Save Changes'}
+            </button>
+            <Link to="/admin/quizzes" className="btn-secondary">
+              Cancel
+            </Link>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/ManageQuizzes.tsx
+++ b/frontend/src/pages/admin/ManageQuizzes.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { getExtractionJobs, publishQuiz } from '../../api/client';
+import { useAccessToken } from '../../hooks/useAccessToken';
+import type { ExtractionJob } from '../../types';
+
+function formatTitle(fileName: string): string {
+  return fileName
+    .replace(/\.pdf$/i, '')
+    .replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export default function ManageQuizzes() {
+  const { getToken } = useAccessToken();
+  const [quizzes, setQuizzes] = useState<ExtractionJob[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [toggling, setToggling] = useState<string | null>(null);
+
+  useEffect(() => {
+    getToken()
+      .then((token) => getExtractionJobs(token))
+      .then((res) => setQuizzes(res.jobs.filter((j) => j.published)))
+      .catch(console.error)
+      .finally(() => setLoading(false));
+  }, [getToken]);
+
+  const toggleVisibility = async (quiz: ExtractionJob) => {
+    setToggling(quiz.jobId);
+    try {
+      const token = await getToken();
+      await publishQuiz(quiz.jobId, token, true, !quiz.isPublic);
+      setQuizzes((prev) =>
+        prev.map((q) => (q.jobId === quiz.jobId ? { ...q, isPublic: !q.isPublic } : q))
+      );
+    } catch (err) {
+      console.error('Toggle failed:', err);
+    } finally {
+      setToggling(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="text-center">
+          <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+          <p className="mt-2 text-gray-600">Loading quizzes...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Manage Quizzes</h1>
+          <p className="text-gray-600">View and manage all published quizzes</p>
+        </div>
+        <Link
+          to="/admin/create"
+          className="px-4 py-2 rounded-lg font-medium bg-primary-600 text-white hover:bg-primary-700"
+        >
+          Create Quiz
+        </Link>
+      </div>
+
+      {quizzes.length === 0 ? (
+        <div className="bg-white rounded-lg shadow p-8 text-center text-gray-500">
+          No published quizzes yet.{' '}
+          <Link to="/admin/create" className="text-primary-600 hover:underline">
+            Create one
+          </Link>
+        </div>
+      ) : (
+        <div className="bg-white rounded-lg shadow overflow-hidden">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  Title
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  Category
+                </th>
+                <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase">
+                  Questions
+                </th>
+                <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase">
+                  Visibility
+                </th>
+                <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase">
+                  Time
+                </th>
+                <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase">
+                  Shuffle
+                </th>
+                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {quizzes.map((quiz) => (
+                <tr key={quiz.jobId} className="hover:bg-gray-50">
+                  <td className="px-6 py-4">
+                    <Link
+                      to={`/admin/quizzes/${quiz.jobId}`}
+                      className="font-medium text-gray-900 hover:text-primary-600"
+                    >
+                      {formatTitle(quiz.fileName)}
+                    </Link>
+                    {quiz.description && (
+                      <p className="text-sm text-gray-500 truncate max-w-xs">{quiz.description}</p>
+                    )}
+                  </td>
+                  <td className="px-6 py-4 text-sm text-gray-600">
+                    {quiz.category || 'Laws of the Game'}
+                  </td>
+                  <td className="px-6 py-4 text-center text-sm font-medium">
+                    {quiz.approvedCount}
+                  </td>
+                  <td className="px-6 py-4 text-center">
+                    <button
+                      onClick={() => toggleVisibility(quiz)}
+                      disabled={toggling === quiz.jobId}
+                      className={`px-3 py-1 text-xs font-medium rounded-full transition-colors disabled:opacity-50 ${
+                        quiz.isPublic
+                          ? 'bg-blue-100 text-blue-800 hover:bg-blue-200'
+                          : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                      }`}
+                    >
+                      {quiz.isPublic ? '🌐 Public' : '🔒 Private'}
+                    </button>
+                  </td>
+                  <td className="px-6 py-4 text-center text-sm text-gray-600">
+                    {quiz.timeLimitMinutes ? `${quiz.timeLimitMinutes}m` : '—'}
+                  </td>
+                  <td className="px-6 py-4 text-center text-sm text-gray-600">
+                    {quiz.shuffleOptions !== false ? '✓' : '—'}
+                  </td>
+                  <td className="px-6 py-4 text-right">
+                    <div className="flex items-center justify-end gap-2">
+                      <Link
+                        to={`/admin/quizzes/${quiz.jobId}`}
+                        className="text-sm text-primary-600 hover:text-primary-700 font-medium"
+                      >
+                        Manage
+                      </Link>
+                      <Link
+                        to={`/admin/quizzes/${quiz.jobId}/edit`}
+                        className="text-sm text-gray-600 hover:text-gray-800 font-medium"
+                      >
+                        Edit
+                      </Link>
+                      <a
+                        href={`/quiz/${quiz.jobId}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-sm text-gray-400 hover:text-gray-600"
+                        title="View quiz"
+                      >
+                        ↗
+                      </a>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/QuizQuestions.tsx
+++ b/frontend/src/pages/admin/QuizQuestions.tsx
@@ -1,0 +1,324 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import {
+  getExtractionJob,
+  getQuestionBank,
+  addManualQuestion,
+  removeQuizQuestion,
+} from '../../api/client';
+import { useAccessToken } from '../../hooks/useAccessToken';
+import type { JobDetailResponse, BankQuestion, Law } from '../../types';
+
+const LAWS: Law[] = [
+  'Law 1',
+  'Law 2',
+  'Law 3',
+  'Law 4',
+  'Law 5',
+  'Law 6',
+  'Law 7',
+  'Law 8',
+  'Law 9',
+  'Law 10',
+  'Law 11',
+  'Law 12',
+  'Law 13',
+  'Law 14',
+  'Law 15',
+  'Law 16',
+  'Law 17',
+];
+
+function formatTitle(fileName: string): string {
+  return fileName
+    .replace(/\.pdf$/i, '')
+    .replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export default function QuizQuestions() {
+  const { jobId } = useParams<{ jobId: string }>();
+  const { getToken } = useAccessToken();
+
+  const [job, setJob] = useState<JobDetailResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [removing, setRemoving] = useState<string | null>(null);
+
+  // Question picker state
+  const [showPicker, setShowPicker] = useState(false);
+  const [bankQuestions, setBankQuestions] = useState<BankQuestion[]>([]);
+  const [bankLoading, setBankLoading] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [lawPickerFilter, setLawPickerFilter] = useState<'' | Law>('');
+  const [adding, setAdding] = useState(false);
+
+  useEffect(() => {
+    if (!jobId) return;
+    getToken()
+      .then((token) => getExtractionJob(jobId, token))
+      .then(setJob)
+      .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load'))
+      .finally(() => setLoading(false));
+  }, [jobId, getToken]);
+
+  const loadBank = async () => {
+    setBankLoading(true);
+    try {
+      const token = await getToken();
+      const res = await getQuestionBank(token, {
+        status: 'approved',
+        limit: 200,
+        law: lawPickerFilter || undefined,
+      });
+      setBankQuestions(res.questions);
+    } catch {
+      setBankQuestions([]);
+    } finally {
+      setBankLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (showPicker) loadBank();
+  }, [showPicker, lawPickerFilter]);
+
+  const handleRemove = async (questionId: string) => {
+    if (!jobId || !confirm('Remove this question from the quiz?')) return;
+    setRemoving(questionId);
+    try {
+      const token = await getToken();
+      const res = await removeQuizQuestion(jobId, questionId, token);
+      setJob((prev) =>
+        prev
+          ? {
+              ...prev,
+              approvedCount: res.approvedCount,
+              questions: prev.questions.filter((q) => q.questionId !== questionId),
+            }
+          : prev
+      );
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to remove');
+    } finally {
+      setRemoving(null);
+    }
+  };
+
+  const handleAddSelected = async () => {
+    if (!jobId || selected.size === 0) return;
+    setAdding(true);
+    try {
+      const token = await getToken();
+      const toAdd = bankQuestions.filter((q) => selected.has(q.questionId));
+      await Promise.all(
+        toAdd.map((q) =>
+          addManualQuestion(
+            jobId,
+            {
+              text: q.text,
+              options: q.options,
+              correctAnswer: q.correctAnswer,
+              explanation: q.explanation,
+              law: q.law,
+              lawReference: q.lawReference,
+              difficulty: q.difficulty,
+              tags: q.tags,
+            },
+            token
+          )
+        )
+      );
+      // Reload job data
+      const data = await getExtractionJob(jobId, token);
+      setJob(data);
+      setSelected(new Set());
+      setShowPicker(false);
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to add questions');
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+      </div>
+    );
+  }
+
+  if (!job) {
+    return (
+      <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
+        <p className="text-red-700">{error || 'Quiz not found'}</p>
+        <Link to="/admin/quizzes" className="mt-4 inline-block btn-secondary">
+          Back
+        </Link>
+      </div>
+    );
+  }
+
+  const approvedQuestions = job.questions.filter((q) => q.status === 'approved');
+  const existingIds = new Set(job.questions.map((q) => q.questionId));
+  const availableBank = bankQuestions.filter((q) => !existingIds.has(q.questionId));
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          to="/admin/quizzes"
+          className="text-sm text-gray-500 hover:text-gray-700 mb-2 inline-block"
+        >
+          ← Back to Quizzes
+        </Link>
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">{formatTitle(job.fileName)}</h1>
+            <p className="text-gray-600">
+              {approvedQuestions.length} questions · {job.category || 'Laws of the Game'}
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setShowPicker(!showPicker)}
+              className="px-4 py-2 rounded-lg font-medium bg-primary-600 text-white hover:bg-primary-700"
+            >
+              {showPicker ? 'Cancel' : 'Add Questions'}
+            </button>
+            <Link to={`/admin/quizzes/${jobId}/edit`} className="btn-secondary">
+              Edit Metadata
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      {/* Question Picker */}
+      {showPicker && (
+        <div className="mb-8 bg-blue-50 border border-blue-200 rounded-lg p-6">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Add Questions from Bank</h2>
+          <div className="mb-4 flex items-center gap-4 flex-wrap">
+            <select
+              value={lawPickerFilter}
+              onChange={(e) => setLawPickerFilter(e.target.value as '' | Law)}
+              className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            >
+              <option value="">All Laws</option>
+              {LAWS.map((l) => (
+                <option key={l} value={l}>
+                  {l}
+                </option>
+              ))}
+            </select>
+            <span className="text-sm text-gray-500">
+              {selected.size} selected · {availableBank.length} available
+            </span>
+          </div>
+          <div className="bg-white rounded-lg border divide-y divide-gray-200 max-h-[40vh] overflow-y-auto mb-4">
+            {bankLoading ? (
+              <div className="p-6 text-center text-gray-500">Loading...</div>
+            ) : availableBank.length === 0 ? (
+              <div className="p-6 text-center text-gray-500">
+                No available questions{lawPickerFilter ? ` for ${lawPickerFilter}` : ''}
+              </div>
+            ) : (
+              availableBank.map((q) => (
+                <label
+                  key={q.questionId}
+                  className={`flex items-start gap-3 px-4 py-3 cursor-pointer hover:bg-gray-50 ${selected.has(q.questionId) ? 'bg-primary-50' : ''}`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selected.has(q.questionId)}
+                    onChange={() =>
+                      setSelected((prev) => {
+                        const n = new Set(prev);
+                        n.has(q.questionId) ? n.delete(q.questionId) : n.add(q.questionId);
+                        return n;
+                      })
+                    }
+                    className="mt-1 w-4 h-4 text-primary-600 rounded"
+                  />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex gap-2 mb-1">
+                      <span className="text-xs font-medium px-2 py-0.5 bg-blue-100 text-blue-800 rounded">
+                        {q.law}
+                      </span>
+                      {q.difficulty && (
+                        <span className="text-xs px-2 py-0.5 bg-gray-100 text-gray-600 rounded">
+                          {q.difficulty}
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-sm text-gray-900">{q.text}</p>
+                  </div>
+                </label>
+              ))
+            )}
+          </div>
+          <button
+            onClick={handleAddSelected}
+            disabled={adding || selected.size === 0}
+            className="btn-primary disabled:opacity-50"
+          >
+            {adding
+              ? 'Adding...'
+              : `Add ${selected.size} Question${selected.size !== 1 ? 's' : ''}`}
+          </button>
+        </div>
+      )}
+
+      {/* Current Questions */}
+      <div className="bg-white rounded-lg shadow">
+        <div className="px-6 py-4 border-b border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900">
+            Questions ({approvedQuestions.length})
+          </h2>
+        </div>
+        <div className="divide-y divide-gray-200">
+          {approvedQuestions.length === 0 ? (
+            <div className="px-6 py-8 text-center text-gray-500">
+              No questions in this quiz yet.
+            </div>
+          ) : (
+            approvedQuestions.map((q, idx) => (
+              <div key={q.questionId} className="px-6 py-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2 mb-2">
+                      <span className="text-sm font-medium text-gray-400">{idx + 1}.</span>
+                      <span className="text-xs font-medium px-2 py-0.5 bg-blue-100 text-blue-800 rounded">
+                        {q.law}
+                      </span>
+                    </div>
+                    <p className="text-gray-900 mb-2">{q.text}</p>
+                    <div className="grid gap-1">
+                      {q.options.map((opt, i) => (
+                        <div
+                          key={i}
+                          className={`px-3 py-1.5 rounded text-sm ${i === q.correctAnswer ? 'bg-green-50 border border-green-200 text-green-800' : 'bg-gray-50 text-gray-700'}`}
+                        >
+                          <span className="font-medium mr-2">{String.fromCharCode(65 + i)}.</span>
+                          {opt}
+                          {i === q.correctAnswer && <span className="ml-2 text-green-600">✓</span>}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <button
+                    onClick={() => handleRemove(q.questionId)}
+                    disabled={removing === q.questionId}
+                    className="px-3 py-1 text-sm font-medium text-red-700 bg-red-100 rounded hover:bg-red-200 disabled:opacity-50 flex-shrink-0"
+                  >
+                    {removing === q.questionId ? '...' : 'Remove'}
+                  </button>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -198,6 +198,17 @@ export interface AddManualQuestionResponse {
   message: string;
 }
 
+export interface UpdateQuizMetadataRequest {
+  title?: string;
+  description?: string;
+  category?: string;
+  timeLimitMinutes?: number | null;
+  questionsPerAttempt?: number | null;
+  lawFilter?: Law | null;
+  shuffleOptions?: boolean;
+  isPublic?: boolean;
+}
+
 // Quiz submission types
 export interface SubmitAnswersRequest {
   answers: Answer[];


### PR DESCRIPTION
## Summary

Closes #61

Adds a new **Manage Quizzes** section to the admin panel for managing published quizzes — editing metadata, toggling visibility, and adding/removing questions.

## New Admin Pages

### /admin/quizzes — Quiz List
- Table of all published quizzes with: title, category, question count, visibility toggle, time limit, shuffle status
- Inline public/private toggle
- Links to Manage (questions), Edit (metadata), and View (public quiz)

### /admin/quizzes/:id — Quiz Questions
- Lists all approved questions with law badges and correct answer highlighting
- Remove button per question (with confirmation)
- "Add Questions" opens a picker to select approved questions from the bank with law filter
- Reuses the question picker pattern from CreateQuiz

### /admin/quizzes/:id/edit — Edit Quiz
- Form for: title, description, category, time limit, questions per attempt, law filter, shuffle options, public flag
- Pre-populated from existing quiz data

## New Backend Endpoints

- `PUT /admin/jobs/{id}/metadata` — update quiz metadata (title, description, category, timeLimitMinutes, questionsPerAttempt, lawFilter, shuffleOptions, isPublic)
- `DELETE /admin/jobs/{id}/questions/{questionId}` — remove a question from a quiz (sets status to rejected, decrements approved count)

## Infrastructure
- Two new Lambda functions with API Gateway routes behind JWT authorizer
- CORS modules for new routes
- Updated deployment triggers and outputs

## What was tested
- Backend builds cleanly (16 handlers)
- Frontend builds cleanly (71 modules)
- Prettier and commitlint pass