### PR TITLE
feat: add study mode with instant feedback

### DIFF
--- a/backend/src/handlers/getQuestions.ts
+++ b/backend/src/handlers/getQuestions.ts
@@ -1,4 +1,9 @@
-import type { APIGatewayProxyEvent, APIGatewayProxyResult, Question } from '../lib/types.js';
+import type {
+  APIGatewayProxyEvent,
+  APIGatewayProxyResult,
+  Question,
+  QuestionWithAnswer,
+} from '../lib/types.js';
 import {
   getApprovedQuestionsByJobId,
   getExtractionJob,
@@ -10,13 +15,16 @@ import { verifyToken } from '../lib/verifyToken.js';
 
 /**
  * GET /quizzes/{id}/questions
- * Returns randomized questions for a quiz (without correct answers)
+ * Returns randomized questions for a quiz.
+ * ?mode=study requires auth and includes correct answers + explanations.
  */
 export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
   console.log('Event:', JSON.stringify(event, null, 2));
 
   const quizId = event.pathParameters?.id;
   const limitParam = event.queryStringParameters?.limit;
+  const mode = event.queryStringParameters?.mode;
+  const isStudyMode = mode === 'study';
 
   if (!quizId) {
     return errorResponse('Missing quiz ID', 400);
@@ -31,15 +39,14 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
   }
 
   try {
-    // Verify the job exists and is published
     const job = await getExtractionJob(quizId);
 
     if (!job || !job.published || job.approvedCount === 0) {
       return errorResponse('Quiz not found', 404);
     }
 
-    // Enforce auth for non-public quizzes
-    if (!job.isPublic) {
+    // Study mode always requires auth; non-public quizzes also require auth
+    if (isStudyMode || !job.isPublic) {
       const userId = await verifyToken(
         event.headers?.Authorization || event.headers?.authorization
       );
@@ -48,7 +55,6 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
       }
     }
 
-    // Get approved questions for this job, optionally narrowed by the quiz's law filter
     const allQuestions = await getApprovedQuestionsByJobId(quizId);
     const questions = job.lawFilter
       ? allQuestions.filter((q) => q.law === job.lawFilter)
@@ -61,14 +67,19 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
     const effectiveLimit = limit ?? job.questionsPerAttempt ?? 10;
     const shuffled = shuffleArray(questions).slice(0, effectiveLimit);
 
-    // Transform to response format (without correct answers)
-    const response: Question[] = shuffled.map((q) => ({
-      questionId: q.questionId,
-      text: q.text,
-      options: q.options,
-    }));
+    const response: (Question | QuestionWithAnswer)[] = shuffled.map((q) =>
+      isStudyMode
+        ? {
+            questionId: q.questionId,
+            text: q.text,
+            options: q.options,
+            correctAnswer: q.correctAnswer,
+            explanation: q.explanation || 'No explanation available.',
+            lawReference: q.lawReference || q.law || 'N/A',
+          }
+        : { questionId: q.questionId, text: q.text, options: q.options }
+    );
 
-    // Track usage for the selected questions (fire and forget)
     const questionIds = shuffled.map((q) => q.questionId);
     updateQuestionUsage(questionIds).catch((err) => {
       console.error('Error updating question usage:', err);

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -57,10 +57,18 @@ export async function getQuiz(quizId: string): Promise<QuizDetail> {
 export async function getQuestions(
   quizId: string,
   limit?: number,
-  token?: string
+  token?: string,
+  mode?: 'exam' | 'study'
 ): Promise<Question[]> {
-  const query = limit !== undefined ? `?limit=${limit}` : '';
-  return fetchAPI<Question[]>(`/quizzes/${quizId}/questions${query}`, undefined, token);
+  const params = new URLSearchParams();
+  if (limit !== undefined) params.set('limit', limit.toString());
+  if (mode === 'study') params.set('mode', 'study');
+  const query = params.toString();
+  return fetchAPI<Question[]>(
+    `/quizzes/${quizId}/questions${query ? `?${query}` : ''}`,
+    undefined,
+    token
+  );
 }
 
 export async function submitAnswers(

--- a/frontend/src/pages/QuizTake.tsx
+++ b/frontend/src/pages/QuizTake.tsx
@@ -2,11 +2,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
 import { getQuiz, getQuestions } from '../api/client';
-import type { QuizDetail, Question, Answer } from '../types';
+import type { QuizDetail, Question, StudyQuestion, Answer } from '../types';
 
 const OPTION_LABELS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
-/** Fisher-Yates shuffle returning a new array */
 function shuffleArray<T>(arr: T[]): T[] {
   const a = [...arr];
   for (let i = a.length - 1; i > 0; i--) {
@@ -16,10 +15,6 @@ function shuffleArray<T>(arr: T[]): T[] {
   return a;
 }
 
-/**
- * For each question, build a shuffled index order.
- * shuffleMap[questionId][displayIndex] = originalIndex
- */
 function buildShuffleMap(questions: Question[]): Record<string, number[]> {
   const map: Record<string, number[]> = {};
   for (const q of questions) {
@@ -35,6 +30,12 @@ function formatTime(seconds: number): string {
   return `${m}:${s.toString().padStart(2, '0')}`;
 }
 
+type QuizMode = 'exam' | 'study';
+
+function isStudyQuestion(q: Question): q is StudyQuestion {
+  return 'correctAnswer' in q;
+}
+
 export default function QuizTake() {
   const { quizId } = useParams<{ quizId: string }>();
   const navigate = useNavigate();
@@ -45,15 +46,19 @@ export default function QuizTake() {
     getIdTokenClaims,
   } = useAuth0();
 
+  // Phase: 'select' (mode selection), 'quiz' (taking quiz), or 'auth' (login required)
+  const [phase, setPhase] = useState<'loading' | 'select' | 'auth' | 'quiz' | 'error'>('loading');
   const [quiz, setQuiz] = useState<QuizDetail | null>(null);
+  const [mode, setMode] = useState<QuizMode>('exam');
   const [questions, setQuestions] = useState<Question[]>([]);
   const [shuffleMap, setShuffleMap] = useState<Record<string, number[]>>({});
   const [answers, setAnswers] = useState<Answer[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [secondsLeft, setSecondsLeft] = useState<number | null>(null);
-  const [requiresAuth, setRequiresAuth] = useState(false);
+
+  // Study mode: whether current question feedback is revealed
+  const [feedbackRevealed, setFeedbackRevealed] = useState(false);
 
   const answersRef = useRef<Answer[]>([]);
   const questionsRef = useRef<Question[]>([]);
@@ -62,69 +67,74 @@ export default function QuizTake() {
   useEffect(() => {
     answersRef.current = answers;
   }, [answers]);
-
   useEffect(() => {
     questionsRef.current = questions;
   }, [questions]);
 
+  // Load quiz metadata
   useEffect(() => {
-    async function loadQuiz() {
-      if (!quizId || authLoading) return;
-
-      try {
-        const quizData = await getQuiz(quizId);
-
-        if (!quizData.isPublic && !isAuthenticated) {
-          setQuiz(quizData);
-          setRequiresAuth(true);
-          setLoading(false);
-          return;
+    if (!quizId || authLoading) return;
+    getQuiz(quizId)
+      .then((data) => {
+        setQuiz(data);
+        if (!data.isPublic && !isAuthenticated) {
+          setPhase('auth');
+        } else {
+          setPhase('select');
         }
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : 'Failed to load quiz');
+        setPhase('error');
+      });
+  }, [quizId, isAuthenticated, authLoading]);
 
+  // Start quiz with selected mode
+  const startQuiz = useCallback(
+    async (selectedMode: QuizMode) => {
+      if (!quizId || !quiz) return;
+      setMode(selectedMode);
+      setPhase('loading');
+      try {
         let token: string | undefined;
         if (isAuthenticated) {
           const claims = await getIdTokenClaims();
           token = claims?.__raw;
         }
-        const questionsData = await getQuestions(quizId, undefined, token);
-        setQuiz(quizData);
-        setQuestions(questionsData);
-        const shouldShuffle = quizData.shuffleOptions !== false;
-        setShuffleMap(shouldShuffle ? buildShuffleMap(questionsData) : {});
+        const data = await getQuestions(quizId, undefined, token, selectedMode);
+        setQuestions(data);
+        const shouldShuffle = quiz.shuffleOptions !== false;
+        setShuffleMap(shouldShuffle ? buildShuffleMap(data) : {});
         sessionStorage.setItem('quizStartedAt', Date.now().toString());
-        if (quizData.timeLimitMinutes && quizData.timeLimitMinutes > 0) {
-          setSecondsLeft(quizData.timeLimitMinutes * 60);
+        if (selectedMode === 'exam' && quiz.timeLimitMinutes && quiz.timeLimitMinutes > 0) {
+          setSecondsLeft(quiz.timeLimitMinutes * 60);
         }
+        setPhase('quiz');
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load quiz');
-      } finally {
-        setLoading(false);
+        setError(err instanceof Error ? err.message : 'Failed to load questions');
+        setPhase('error');
       }
-    }
-
-    loadQuiz();
-  }, [quizId, isAuthenticated, authLoading]);
+    },
+    [quizId, quiz, isAuthenticated, getIdTokenClaims]
+  );
 
   const submit = useCallback(
     (auto: boolean) => {
       if (!quizId || submittedRef.current) return;
       submittedRef.current = true;
-
-      // Pad unanswered with -1 so the backend's score divisor stays correct
       const finalAnswers: Answer[] = questionsRef.current.map((q) => {
         const existing = answersRef.current.find((a) => a.questionId === q.questionId);
         return existing ?? { questionId: q.questionId, selectedOption: -1 };
       });
-
       sessionStorage.setItem('quizAnswers', JSON.stringify(finalAnswers));
       sessionStorage.setItem('quizQuestions', JSON.stringify(questionsRef.current));
       sessionStorage.setItem('quizAutoSubmitted', auto ? 'true' : 'false');
-
       navigate(`/quiz/${quizId}/results`);
     },
     [quizId, navigate]
   );
 
+  // Timer (exam mode only)
   useEffect(() => {
     if (secondsLeft === null) return;
     if (secondsLeft <= 0) {
@@ -147,10 +157,9 @@ export default function QuizTake() {
 
   const handleSelectOption = useCallback(
     (displayIndex: number) => {
-      if (!currentQuestion) return;
+      if (!currentQuestion || (mode === 'study' && feedbackRevealed)) return;
       const order = shuffleMap[currentQuestion.questionId];
       const originalIndex = order ? order[displayIndex] : displayIndex;
-
       setAnswers((prev) => {
         const existing = prev.find((a) => a.questionId === currentQuestion.questionId);
         if (existing) {
@@ -163,14 +172,20 @@ export default function QuizTake() {
         return [...prev, { questionId: currentQuestion.questionId, selectedOption: originalIndex }];
       });
     },
-    [currentQuestion, shuffleMap]
+    [currentQuestion, shuffleMap, mode, feedbackRevealed]
   );
 
+  const handleCheck = useCallback(() => {
+    setFeedbackRevealed(true);
+  }, []);
+
   const handleNext = useCallback(() => {
+    setFeedbackRevealed(false);
     setCurrentIndex((i) => (i < questions.length - 1 ? i + 1 : i));
   }, [questions.length]);
 
   const handlePrevious = useCallback(() => {
+    setFeedbackRevealed(false);
     setCurrentIndex((i) => (i > 0 ? i - 1 : i));
   }, []);
 
@@ -180,26 +195,30 @@ export default function QuizTake() {
   const answeredCount = answers.filter((a) => a.selectedOption >= 0).length;
   const canSubmit = answeredCount === questions.length && questions.length > 0;
   const lowTime = secondsLeft !== null && secondsLeft <= 60;
+  const hasAnswered = currentAnswer !== undefined && currentAnswer.selectedOption >= 0;
 
+  // Keyboard shortcuts
   useEffect(() => {
-    if (loading || error || !currentQuestion) return;
-
+    if (phase !== 'quiz' || !currentQuestion) return;
     const onKeyDown = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement | null;
-      if (target?.isContentEditable) return;
-      const tag = target?.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      if (
+        target?.isContentEditable ||
+        target?.tagName === 'INPUT' ||
+        target?.tagName === 'TEXTAREA' ||
+        target?.tagName === 'SELECT'
+      )
+        return;
       if (e.metaKey || e.ctrlKey || e.altKey) return;
 
       if (e.key >= 'a' && e.key <= 'z') {
-        const idx = e.key.charCodeAt(0) - 97; // a=0, b=1, c=2, d=3
+        const idx = e.key.charCodeAt(0) - 97;
         if (idx < currentQuestion.options.length) {
           e.preventDefault();
           handleSelectOption(idx);
         }
         return;
       }
-
       if (e.key === 'ArrowRight') {
         if (!isLast) {
           e.preventDefault();
@@ -207,7 +226,6 @@ export default function QuizTake() {
         }
         return;
       }
-
       if (e.key === 'ArrowLeft') {
         if (currentIndex > 0) {
           e.preventDefault();
@@ -215,25 +233,23 @@ export default function QuizTake() {
         }
         return;
       }
-
       if (e.key === 'Enter') {
-        if (isLast) {
-          if (canSubmit) {
-            e.preventDefault();
-            handleSubmit();
-          }
-        } else {
-          e.preventDefault();
+        e.preventDefault();
+        if (mode === 'study' && hasAnswered && !feedbackRevealed) {
+          handleCheck();
+        } else if (mode === 'study' && feedbackRevealed) {
+          isLast ? handleSubmit() : handleNext();
+        } else if (isLast && canSubmit) {
+          handleSubmit();
+        } else if (!isLast) {
           handleNext();
         }
       }
     };
-
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [
-    loading,
-    error,
+    phase,
     currentQuestion,
     currentIndex,
     isLast,
@@ -242,9 +258,15 @@ export default function QuizTake() {
     handleNext,
     handlePrevious,
     handleSubmit,
+    handleCheck,
+    mode,
+    hasAnswered,
+    feedbackRevealed,
   ]);
 
-  if (loading) {
+  // --- RENDER PHASES ---
+
+  if (phase === 'loading') {
     return (
       <div className="flex items-center justify-center min-h-screen">
         <div className="text-center">
@@ -255,7 +277,7 @@ export default function QuizTake() {
     );
   }
 
-  if (requiresAuth) {
+  if (phase === 'auth') {
     return (
       <div className="flex items-center justify-center min-h-screen">
         <div className="card max-w-md text-center">
@@ -277,7 +299,7 @@ export default function QuizTake() {
     );
   }
 
-  if (error || !quiz || !currentQuestion) {
+  if (phase === 'error') {
     return (
       <div className="flex items-center justify-center min-h-screen">
         <div className="card max-w-md">
@@ -291,19 +313,90 @@ export default function QuizTake() {
     );
   }
 
+  // Mode selection screen
+  if (phase === 'select' && quiz) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="card max-w-lg text-center">
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">{quiz.title}</h2>
+          <p className="text-gray-600 mb-8">
+            {quiz.questionCount} questions
+            {quiz.timeLimitMinutes ? ` · ${quiz.timeLimitMinutes} min` : ''}
+          </p>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <button
+              onClick={() => startQuiz('exam')}
+              className="p-6 rounded-xl border-2 border-gray-200 hover:border-primary-500 hover:bg-primary-50 transition-all text-left"
+            >
+              <div className="text-2xl mb-2">📝</div>
+              <div className="font-semibold text-gray-900 mb-1">Exam Mode</div>
+              <p className="text-sm text-gray-500">
+                Answer all questions, then see your results.
+                {quiz.timeLimitMinutes
+                  ? ` ${quiz.timeLimitMinutes} minute time limit.`
+                  : ' No time limit.'}
+              </p>
+            </button>
+            {isAuthenticated ? (
+              <button
+                onClick={() => startQuiz('study')}
+                className="p-6 rounded-xl border-2 border-gray-200 hover:border-green-500 hover:bg-green-50 transition-all text-left"
+              >
+                <div className="text-2xl mb-2">📖</div>
+                <div className="font-semibold text-gray-900 mb-1">Study Mode</div>
+                <p className="text-sm text-gray-500">
+                  Get instant feedback and explanations after each question. No timer.
+                </p>
+              </button>
+            ) : (
+              <div className="p-6 rounded-xl border-2 border-gray-200 bg-gray-50 text-left opacity-75">
+                <div className="text-2xl mb-2">📖</div>
+                <div className="font-semibold text-gray-900 mb-1">Study Mode</div>
+                <p className="text-sm text-gray-500 mb-3">
+                  Get instant feedback and explanations after each question.
+                </p>
+                <button
+                  onClick={() => loginWithRedirect()}
+                  className="text-sm font-medium text-primary-600 hover:text-primary-700"
+                >
+                  Log in to unlock →
+                </button>
+              </div>
+            )}
+          </div>
+          <button
+            onClick={() => navigate('/')}
+            className="mt-6 text-sm text-gray-500 hover:text-gray-700"
+          >
+            ← Back to Quizzes
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Quiz phase
+  if (!quiz || !currentQuestion) return null;
+
   const progress = ((currentIndex + 1) / questions.length) * 100;
+  const studyQ = mode === 'study' && isStudyQuestion(currentQuestion) ? currentQuestion : null;
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-3xl">
       <div className="mb-6">
         <div className="flex items-center justify-between mb-2">
-          <h1 className="text-2xl font-bold text-gray-900">{quiz.title}</h1>
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-bold text-gray-900">{quiz.title}</h1>
+            {mode === 'study' && (
+              <span className="px-2 py-0.5 text-xs font-medium bg-green-100 text-green-800 rounded-full">
+                Study
+              </span>
+            )}
+          </div>
           <div className="flex items-center gap-4">
             {secondsLeft !== null && (
               <span
-                className={`text-sm font-mono font-semibold px-3 py-1 rounded-full ${
-                  lowTime ? 'bg-red-100 text-red-700' : 'bg-gray-100 text-gray-700'
-                }`}
+                className={`text-sm font-mono font-semibold px-3 py-1 rounded-full ${lowTime ? 'bg-red-100 text-red-700' : 'bg-gray-100 text-gray-700'}`}
                 aria-label="Time remaining"
               >
                 {formatTime(Math.max(0, secondsLeft))}
@@ -330,29 +423,49 @@ export default function QuizTake() {
             const originalIndex =
               shuffleMap[currentQuestion.questionId]?.[displayIndex] ?? displayIndex;
             const isSelected = currentAnswer?.selectedOption === originalIndex;
+            const showFeedback = mode === 'study' && feedbackRevealed && studyQ;
+            const isCorrect = showFeedback && originalIndex === studyQ.correctAnswer;
+            const isWrong = showFeedback && isSelected && originalIndex !== studyQ.correctAnswer;
+
+            let borderClass = 'border-gray-200 hover:border-gray-300 bg-white';
+            if (showFeedback && isCorrect) borderClass = 'border-green-500 bg-green-50';
+            else if (showFeedback && isWrong) borderClass = 'border-red-500 bg-red-50';
+            else if (isSelected) borderClass = 'border-primary-600 bg-primary-50';
+
             return (
               <button
                 key={displayIndex}
                 onClick={() => handleSelectOption(displayIndex)}
-                className={`w-full text-left p-4 rounded-lg border-2 transition-all ${
-                  isSelected
-                    ? 'border-primary-600 bg-primary-50'
-                    : 'border-gray-200 hover:border-gray-300 bg-white'
-                }`}
+                disabled={mode === 'study' && feedbackRevealed}
+                className={`w-full text-left p-4 rounded-lg border-2 transition-all disabled:cursor-default ${borderClass}`}
               >
                 <div className="flex items-center">
                   <div
                     className={`flex-shrink-0 w-6 h-6 rounded-full border-2 mr-3 flex items-center justify-center ${
-                      isSelected ? 'border-primary-600 bg-primary-600' : 'border-gray-300'
+                      showFeedback && isCorrect
+                        ? 'border-green-600 bg-green-600'
+                        : showFeedback && isWrong
+                          ? 'border-red-600 bg-red-600'
+                          : isSelected
+                            ? 'border-primary-600 bg-primary-600'
+                            : 'border-gray-300'
                     }`}
                   >
-                    {isSelected && (
+                    {(isSelected || (showFeedback && isCorrect)) && (
                       <svg className="w-4 h-4 text-white" fill="currentColor" viewBox="0 0 20 20">
-                        <path
-                          fillRule="evenodd"
-                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                          clipRule="evenodd"
-                        />
+                        {showFeedback && isWrong ? (
+                          <path
+                            fillRule="evenodd"
+                            d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                            clipRule="evenodd"
+                          />
+                        ) : (
+                          <path
+                            fillRule="evenodd"
+                            d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                            clipRule="evenodd"
+                          />
+                        )}
                       </svg>
                     )}
                   </div>
@@ -368,6 +481,19 @@ export default function QuizTake() {
             );
           })}
         </div>
+
+        {/* Study mode feedback */}
+        {mode === 'study' && feedbackRevealed && studyQ && (
+          <div className="mt-6 bg-blue-50 border-l-4 border-blue-500 p-4 rounded">
+            <p className="text-sm font-semibold text-blue-900 mb-1">
+              {currentAnswer?.selectedOption === studyQ.correctAnswer
+                ? '✓ Correct!'
+                : '✗ Incorrect'}{' '}
+              — {studyQ.lawReference}
+            </p>
+            <p className="text-sm text-blue-800">{studyQ.explanation}</p>
+          </div>
+        )}
       </div>
 
       <div className="flex items-center justify-between">
@@ -379,13 +505,28 @@ export default function QuizTake() {
           {answeredCount} of {questions.length} answered
         </div>
 
-        {isLast ? (
-          <button onClick={handleSubmit} disabled={!canSubmit} className="btn-primary">
-            Submit Quiz
+        {mode === 'study' && hasAnswered && !feedbackRevealed ? (
+          <button
+            onClick={handleCheck}
+            className="px-6 py-2 rounded-lg font-medium bg-green-600 text-white hover:bg-green-700"
+          >
+            Check Answer
+          </button>
+        ) : isLast ? (
+          <button
+            onClick={handleSubmit}
+            disabled={mode === 'study' ? !feedbackRevealed && hasAnswered : !canSubmit}
+            className="btn-primary"
+          >
+            {mode === 'study' && !feedbackRevealed && !hasAnswered ? 'Submit Quiz' : 'Submit Quiz'}
           </button>
         ) : (
-          <button onClick={handleNext} className="btn-primary">
-            Next →
+          <button
+            onClick={handleNext}
+            disabled={mode === 'study' && hasAnswered && !feedbackRevealed}
+            className="btn-primary"
+          >
+            {mode === 'study' && feedbackRevealed ? 'Continue →' : 'Next →'}
           </button>
         )}
       </div>
@@ -399,7 +540,11 @@ export default function QuizTake() {
         select · <kbd className="px-1.5 py-0.5 bg-gray-100 border border-gray-200 rounded">←</kbd>/
         <kbd className="px-1.5 py-0.5 bg-gray-100 border border-gray-200 rounded">→</kbd> nav ·{' '}
         <kbd className="px-1.5 py-0.5 bg-gray-100 border border-gray-200 rounded">Enter</kbd>{' '}
-        {isLast ? 'submit' : 'next'}
+        {mode === 'study' && hasAnswered && !feedbackRevealed
+          ? 'check'
+          : isLast
+            ? 'submit'
+            : 'next'}
       </p>
     </div>
   );

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -22,6 +22,12 @@ export interface Question {
   options: string[];
 }
 
+export interface StudyQuestion extends Question {
+  correctAnswer: number;
+  explanation: string;
+  lawReference: string;
+}
+
 export interface Answer {
   questionId: string;
   selectedOption: number;


### PR DESCRIPTION
## Summary

Closes #57

Adds a **Study Mode** to quizzes that shows instant feedback (correct/incorrect + explanation + law reference) after each question. Study mode requires login but is free — giving users a reason to sign up.

## How it works

### Mode Selection Screen
When starting a quiz, users now see a mode selection:
- **📝 Exam Mode** — existing behaviour (answer all, see results at end, timer if configured)
- **📖 Study Mode** — instant feedback after each question, no timer

Study mode shows "Log in to unlock →" for unauthenticated users.

### Study Mode Flow
1. Select an answer (A-D)
2. Click **Check Answer** (or press Enter)
3. See feedback: correct answer highlighted green, wrong answer red, explanation callout with law reference
4. Click **Continue →** (or press Enter) to move to next question
5. At the end, still navigates to the results page

### Backend
- `GET /quizzes/{id}/questions?mode=study` requires auth and returns `correctAnswer`, `explanation`, `lawReference` with each question
- Exam mode response unchanged

## What was tested
- Backend and frontend build cleanly
- Keyboard shortcuts work for check/continue flow