### PR TITLE
feat(landing): introductory section above the quiz list

### DIFF
--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -1,0 +1,63 @@
+import { useAuth0 } from '@auth0/auth0-react';
+
+interface HeroProps {
+  onStartClick: () => void;
+}
+
+export default function Hero({ onStartClick }: HeroProps) {
+  const { isAuthenticated, loginWithRedirect } = useAuth0();
+
+  const handleCta = () => {
+    if (isAuthenticated) {
+      onStartClick();
+    } else {
+      loginWithRedirect();
+    }
+  };
+
+  return (
+    <section className="border-b border-gray-200 bg-white">
+      <div className="container mx-auto px-4 py-16 sm:py-20 max-w-4xl">
+        <div className="max-w-2xl">
+          <h1 className="text-3xl sm:text-4xl font-semibold text-gray-900 tracking-tight">
+            Practice the IFAB Laws of the Game
+          </h1>
+          <p className="mt-4 text-base sm:text-lg text-gray-600 leading-relaxed">
+            A quiz tool for football referees. Take timed exams, drill on
+            specific laws, and review every answer with the relevant Law
+            reference.
+          </p>
+          <div className="mt-6 flex flex-col sm:flex-row gap-3">
+            <button onClick={handleCta} className="btn-primary">
+              {isAuthenticated ? 'Browse quizzes' : 'Sign in'}
+            </button>
+            <button onClick={onStartClick} className="btn-secondary">
+              View available quizzes
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-12 grid gap-6 sm:grid-cols-3 text-sm">
+          <FeatureItem title="Timed or untimed">
+            Optional countdown with auto-submit on expiry.
+          </FeatureItem>
+          <FeatureItem title="Filter by law">
+            Restrict a quiz to a single Law to focus practice.
+          </FeatureItem>
+          <FeatureItem title="Reviewable results">
+            Every answer comes with an explanation and Law reference.
+          </FeatureItem>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function FeatureItem({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <p className="font-medium text-gray-900">{title}</p>
+      <p className="mt-1 text-gray-600 leading-relaxed">{children}</p>
+    </div>
+  );
+}

--- a/frontend/src/pages/QuizList.tsx
+++ b/frontend/src/pages/QuizList.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
 import { getQuizzes } from '../api/client';
+import Hero from '../components/Hero';
 import type { QuizSummary } from '../types';
 
 const ALL_CATEGORIES = '__all__';
@@ -13,6 +14,7 @@ export default function QuizList() {
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
   const [category, setCategory] = useState(ALL_CATEGORIES);
+  const quizzesRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     async function loadQuizzes() {
@@ -46,16 +48,9 @@ export default function QuizList() {
     });
   }, [quizzes, search, category]);
 
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-screen">
-        <div className="text-center">
-          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600"></div>
-          <p className="mt-4 text-gray-600">Loading quizzes...</p>
-        </div>
-      </div>
-    );
-  }
+  const scrollToQuizzes = () => {
+    quizzesRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
 
   if (error) {
     return (
@@ -72,120 +67,137 @@ export default function QuizList() {
   const hasQuizzes = quizzes.length > 0;
 
   return (
-    <div className="container mx-auto px-4 py-8 max-w-4xl">
-      <header className="mb-6">
-        <h1 className="text-4xl font-bold text-gray-900 mb-2">Laws of the Game Quizzes</h1>
-        <p className="text-lg text-gray-600">
-          Test your knowledge of football's Laws of the Game (IFAB)
-        </p>
-      </header>
+    <>
+      <Hero onStartClick={scrollToQuizzes} />
 
-      {hasQuizzes && (
-        <div className="mb-6 flex flex-col sm:flex-row gap-3">
-          <div className="flex-1">
-            <label htmlFor="quiz-search" className="sr-only">
-              Search quizzes
-            </label>
-            <input
-              id="quiz-search"
-              type="search"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search quizzes..."
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-            />
-          </div>
-          {categories.length > 1 && (
-            <div className="sm:w-56">
-              <label htmlFor="quiz-category" className="sr-only">
-                Filter by category
-              </label>
-              <select
-                id="quiz-category"
-                value={category}
-                onChange={(e) => setCategory(e.target.value)}
-                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent bg-white"
-              >
-                <option value={ALL_CATEGORIES}>All categories</option>
-                {categories.map((cat) => (
-                  <option key={cat} value={cat}>
-                    {cat}
-                  </option>
-                ))}
-              </select>
+      <div
+        ref={quizzesRef}
+        id="quizzes"
+        className="container mx-auto px-4 py-12 max-w-4xl scroll-mt-16"
+      >
+        <header className="mb-6">
+          <h2 className="text-2xl font-bold text-gray-900">Available Quizzes</h2>
+          <p className="text-gray-600">Pick one to start practising.</p>
+        </header>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-16">
+            <div className="text-center">
+              <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600"></div>
+              <p className="mt-4 text-gray-600">Loading quizzes...</p>
             </div>
-          )}
-        </div>
-      )}
-
-      {hasQuizzes && (
-        <p className="text-sm text-gray-500 mb-4" aria-live="polite">
-          Showing {filtered.length} of {quizzes.length} quizzes
-        </p>
-      )}
-
-      {!hasQuizzes ? (
-        <div className="card text-center">
-          <p className="text-gray-600">No quizzes available yet.</p>
-        </div>
-      ) : filtered.length === 0 ? (
-        <div className="card text-center">
-          <p className="text-gray-600 mb-3">
-            No quizzes match {isFiltering ? 'your filters' : 'your search'}.
-          </p>
-          <button
-            onClick={() => {
-              setSearch('');
-              setCategory(ALL_CATEGORIES);
-            }}
-            className="text-primary-600 hover:underline text-sm font-medium"
-          >
-            Clear filters
-          </button>
-        </div>
-      ) : (
-        <div className="grid gap-6 md:grid-cols-2">
-          {filtered.map((quiz) => {
-            const locked = !quiz.isPublic && !isAuthenticated;
-            return (
-              <Link
-                key={quiz.quizId}
-                to={locked ? '#' : `/quiz/${quiz.quizId}`}
-                onClick={locked ? (e) => e.preventDefault() : undefined}
-                className={`card-hover group ${locked ? 'opacity-50 grayscale pointer-events-auto cursor-not-allowed' : ''}`}
-                aria-disabled={locked}
-              >
-                <div className="flex items-start justify-between mb-3">
-                  <h2 className="text-xl font-semibold text-gray-900 group-hover:text-primary-600 transition-colors">
-                    {quiz.title}
-                  </h2>
-                  <div className="flex items-center gap-2 flex-shrink-0">
-                    {!quiz.isPublic && (
-                      <span title="Login required" className="text-gray-400">
-                        🔒
-                      </span>
-                    )}
-                    <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-primary-100 text-primary-800">
-                      {quiz.questionCount} questions
-                    </span>
+          </div>
+        ) : (
+          <>
+            {hasQuizzes && (
+              <div className="mb-6 flex flex-col sm:flex-row gap-3">
+                <div className="flex-1">
+                  <label htmlFor="quiz-search" className="sr-only">
+                    Search quizzes
+                  </label>
+                  <input
+                    id="quiz-search"
+                    type="search"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    placeholder="Search quizzes..."
+                    className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                  />
+                </div>
+                {categories.length > 1 && (
+                  <div className="sm:w-56">
+                    <label htmlFor="quiz-category" className="sr-only">
+                      Filter by category
+                    </label>
+                    <select
+                      id="quiz-category"
+                      value={category}
+                      onChange={(e) => setCategory(e.target.value)}
+                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent bg-white"
+                    >
+                      <option value={ALL_CATEGORIES}>All categories</option>
+                      {categories.map((cat) => (
+                        <option key={cat} value={cat}>
+                          {cat}
+                        </option>
+                      ))}
+                    </select>
                   </div>
-                </div>
-                <p className="text-gray-600 mb-4">{quiz.description}</p>
-                <div className="flex items-center justify-between">
-                  <span className="text-sm text-gray-500">{quiz.category}</span>
-                  {locked ? (
-                    <span className="text-gray-400 text-sm">Login to access</span>
-                  ) : (
-                    <span className="text-primary-600 group-hover:translate-x-1 transition-transform">
-                      Start Quiz →
-                    </span>
-                  )}
-                </div>
-              </Link>
-            );
-          })}
-        </div>
-      )}
-    </div>
+                )}
+              </div>
+            )}
+
+            {hasQuizzes && (
+              <p className="text-sm text-gray-500 mb-4" aria-live="polite">
+                Showing {filtered.length} of {quizzes.length} quizzes
+              </p>
+            )}
+
+            {!hasQuizzes ? (
+              <div className="card text-center">
+                <p className="text-gray-600">No quizzes available yet.</p>
+              </div>
+            ) : filtered.length === 0 ? (
+              <div className="card text-center">
+                <p className="text-gray-600 mb-3">
+                  No quizzes match {isFiltering ? 'your filters' : 'your search'}.
+                </p>
+                <button
+                  onClick={() => {
+                    setSearch('');
+                    setCategory(ALL_CATEGORIES);
+                  }}
+                  className="text-primary-600 hover:underline text-sm font-medium"
+                >
+                  Clear filters
+                </button>
+              </div>
+            ) : (
+              <div className="grid gap-6 md:grid-cols-2">
+                {filtered.map((quiz) => {
+                  const locked = !quiz.isPublic && !isAuthenticated;
+                  return (
+                    <Link
+                      key={quiz.quizId}
+                      to={locked ? '#' : `/quiz/${quiz.quizId}`}
+                      onClick={locked ? (e) => e.preventDefault() : undefined}
+                      className={`card-hover group ${locked ? 'opacity-50 grayscale pointer-events-auto cursor-not-allowed' : ''}`}
+                      aria-disabled={locked}
+                    >
+                      <div className="flex items-start justify-between mb-3">
+                        <h3 className="text-xl font-semibold text-gray-900 group-hover:text-primary-600 transition-colors">
+                          {quiz.title}
+                        </h3>
+                        <div className="flex items-center gap-2 flex-shrink-0">
+                          {!quiz.isPublic && (
+                            <span title="Login required" className="text-gray-400">
+                              🔒
+                            </span>
+                          )}
+                          <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-primary-100 text-primary-800">
+                            {quiz.questionCount} questions
+                          </span>
+                        </div>
+                      </div>
+                      <p className="text-gray-600 mb-4">{quiz.description}</p>
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm text-gray-500">{quiz.category}</span>
+                        {locked ? (
+                          <span className="text-gray-400 text-sm">Login to access</span>
+                        ) : (
+                          <span className="text-primary-600 group-hover:translate-x-1 transition-transform">
+                            Start Quiz →
+                          </span>
+                        )}
+                      </div>
+                    </Link>
+                  );
+                })}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

Closes #51. Adds a small introductory section above the quiz list so visitors land on something other than a bare grid.

## What's in this PR

A `Hero` component on top of the existing `QuizList` page:

- **Headline + subtitle** — describes what the tool is, in plain language
- **Auth-aware primary CTA** — "Sign in" when logged out (kicks off Auth0 redirect), "Browse quizzes" when logged in (smooth-scrolls to the grid)
- **Secondary "View available quizzes" CTA** — same scroll behaviour for either auth state
- **Three short feature lines** — timed/untimed, filter by law, reviewable results

The quiz grid section below gets a smaller "Available Quizzes" header, an `id="quizzes"` anchor, and `scroll-mt-16` so the sticky navbar doesn't overlap on scroll. Search, category filter, result count, and the freemium lock state from #10 are unchanged.

## Style note

Original copy was over-enthusiastic ("Master the Laws", "For referees, by referees" pill, gradient hero, etc.). Toned it down to plain descriptive copy on a flat background — closer to a tool than a marketing page.

## Test plan

- [ ] Logged out: hero shows "Sign in" primary CTA. Click triggers Auth0 redirect.
- [ ] Logged in: hero shows "Browse quizzes" primary CTA. Click scrolls to the grid.
- [ ] "View available quizzes" secondary CTA always scrolls to the grid.
- [ ] Quiz grid still works — search narrows, category filter narrows, "Showing N of M" updates, locked (`!isPublic`) cards still show grayscale + "Login to access".
- [ ] Mobile: hero text wraps cleanly, CTAs stack, feature items stack.

https://claude.ai/code/session_012ovSD71NbDWLfcCwfsdtE2