### PR TITLE
feat(landing): live sample question + scroll-reveal sections

### DIFF
--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -1,4 +1,5 @@
 import { useAuth0 } from '@auth0/auth0-react';
+import SampleQuestion from './SampleQuestion';
 
 interface HeroProps {
   onStartClick: () => void;
@@ -17,27 +18,33 @@ export default function Hero({ onStartClick }: HeroProps) {
 
   return (
     <section className="border-b border-gray-200 bg-white">
-      <div className="container mx-auto px-4 py-16 sm:py-20 max-w-4xl">
-        <div className="max-w-2xl">
-          <h1 className="text-3xl sm:text-4xl font-semibold text-gray-900 tracking-tight">
-            Practice the IFAB Laws of the Game
-          </h1>
-          <p className="mt-4 text-base sm:text-lg text-gray-600 leading-relaxed">
-            A quiz tool for football referees. Take timed exams, drill on
-            specific laws, and review every answer with the relevant Law
-            reference.
-          </p>
-          <div className="mt-6 flex flex-col sm:flex-row gap-3">
-            <button onClick={handleCta} className="btn-primary">
-              {isAuthenticated ? 'Browse quizzes' : 'Sign in'}
-            </button>
-            <button onClick={onStartClick} className="btn-secondary">
-              View available quizzes
-            </button>
+      <div className="container mx-auto px-4 py-16 sm:py-20 max-w-6xl">
+        <div className="grid lg:grid-cols-2 gap-10 lg:gap-16 items-center">
+          <div>
+            <h1 className="text-3xl sm:text-4xl font-semibold text-gray-900 tracking-tight">
+              Practice the IFAB Laws of the Game
+            </h1>
+            <p className="mt-4 text-base sm:text-lg text-gray-600 leading-relaxed">
+              A quiz tool for football referees. Take timed exams, drill on
+              specific laws, and review every answer with the relevant Law
+              reference.
+            </p>
+            <div className="mt-6 flex flex-col sm:flex-row gap-3">
+              <button onClick={handleCta} className="btn-primary">
+                {isAuthenticated ? 'Browse quizzes' : 'Sign in'}
+              </button>
+              <button onClick={onStartClick} className="btn-secondary">
+                View available quizzes
+              </button>
+            </div>
+          </div>
+
+          <div className="lg:justify-self-end w-full max-w-md mx-auto lg:mx-0">
+            <SampleQuestion />
           </div>
         </div>
 
-        <div className="mt-12 grid gap-6 sm:grid-cols-3 text-sm">
+        <div className="mt-14 sm:mt-16 grid gap-6 sm:grid-cols-3 text-sm border-t border-gray-100 pt-10">
           <FeatureItem title="Timed or untimed">
             Optional countdown with auto-submit on expiry.
           </FeatureItem>

--- a/frontend/src/components/SampleQuestion.tsx
+++ b/frontend/src/components/SampleQuestion.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface SampleQuestion {
+  text: string;
+  options: string[];
+  correctIndex: number;
+  lawReference: string;
+}
+
+const SAMPLES: SampleQuestion[] = [
+  {
+    text: 'How many players from each team are on the field at the start of a match?',
+    options: ['9', '10', '11', '12'],
+    correctIndex: 2,
+    lawReference: 'Law 3',
+  },
+  {
+    text: 'What is the minimum number of players a team must have for a match to continue?',
+    options: ['5', '6', '7', '8'],
+    correctIndex: 2,
+    lawReference: 'Law 3',
+  },
+  {
+    text: 'A back-pass is deliberately kicked by a defender to the goalkeeper. The keeper picks it up. What does the referee award?',
+    options: [
+      'Penalty kick',
+      'Direct free kick',
+      'Indirect free kick from where the keeper handled it',
+      'Drop ball',
+    ],
+    correctIndex: 2,
+    lawReference: 'Law 12',
+  },
+  {
+    text: 'The ball deflects off the referee and goes directly into the goal. What is the correct restart?',
+    options: [
+      'Goal stands',
+      'Drop ball where the deflection happened',
+      'Indirect free kick to the defending team',
+      'Corner kick',
+    ],
+    correctIndex: 1,
+    lawReference: 'Law 9',
+  },
+  {
+    text: 'How is added time at the end of each half determined?',
+    options: [
+      'Always 30 seconds per half',
+      'Fixed at 3 minutes per half',
+      'Decided by the referee, accounting for stoppages',
+      'Decided by the fourth official only',
+    ],
+    correctIndex: 2,
+    lawReference: 'Law 7',
+  },
+];
+
+const LETTERS = ['A', 'B', 'C', 'D'];
+const ROTATION_MS = 8000;
+const REVEAL_DELAY_MS = 3500;
+const FADE_MS = 350;
+
+export default function SampleQuestion() {
+  const [index, setIndex] = useState(0);
+  const [revealed, setRevealed] = useState(false);
+  const [visible, setVisible] = useState(true);
+  const reducedMotion = useRef(
+    typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+
+  useEffect(() => {
+    if (reducedMotion.current) {
+      setRevealed(true);
+      return;
+    }
+
+    const revealTimer = window.setTimeout(() => setRevealed(true), REVEAL_DELAY_MS);
+    const advanceTimer = window.setTimeout(() => {
+      setVisible(false);
+      window.setTimeout(() => {
+        setIndex((i) => (i + 1) % SAMPLES.length);
+        setRevealed(false);
+        setVisible(true);
+      }, FADE_MS);
+    }, ROTATION_MS);
+
+    return () => {
+      window.clearTimeout(revealTimer);
+      window.clearTimeout(advanceTimer);
+    };
+  }, [index]);
+
+  const sample = SAMPLES[index];
+
+  return (
+    <div className="bg-white rounded-2xl shadow-lg ring-1 ring-gray-200 p-6 sm:p-7">
+      <div className="flex items-center justify-between mb-4">
+        <span className="inline-flex items-center gap-2 text-xs font-medium text-gray-500 uppercase tracking-wide">
+          <span className="inline-block w-1.5 h-1.5 bg-primary-500 rounded-full" aria-hidden="true" />
+          Sample question
+        </span>
+        <span className="text-xs font-mono text-gray-400">{sample.lawReference}</span>
+      </div>
+
+      <div
+        className={`transition-opacity ${visible ? 'opacity-100' : 'opacity-0'}`}
+        style={{ transitionDuration: `${FADE_MS}ms` }}
+      >
+        <p className="text-base sm:text-lg font-medium text-gray-900 leading-snug min-h-[3.5rem]">
+          {sample.text}
+        </p>
+
+        <ul className="mt-4 space-y-2">
+          {sample.options.map((opt, i) => {
+            const isCorrect = i === sample.correctIndex;
+            const showCorrect = revealed && isCorrect;
+            return (
+              <li
+                key={i}
+                className={`flex items-center gap-3 rounded-lg border-2 px-3 py-2.5 text-sm transition-colors duration-300 ${
+                  showCorrect
+                    ? 'border-green-500 bg-green-50 text-green-900'
+                    : 'border-gray-200 bg-white text-gray-800'
+                }`}
+              >
+                <span
+                  className={`flex-shrink-0 inline-flex items-center justify-center w-6 h-6 text-xs font-mono font-semibold rounded ${
+                    showCorrect
+                      ? 'bg-green-500 text-white'
+                      : 'bg-gray-100 text-gray-500'
+                  }`}
+                  aria-hidden="true"
+                >
+                  {showCorrect ? '✓' : LETTERS[i]}
+                </span>
+                <span className="flex-1">{opt}</span>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+
+      <div className="mt-5 flex items-center justify-between text-xs text-gray-400">
+        <span aria-live="polite" aria-atomic="true">
+          {index + 1} / {SAMPLES.length}
+        </span>
+        <span>Auto-rotating · pick a quiz to take it for real</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ScrollReveal.tsx
+++ b/frontend/src/components/ScrollReveal.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface ScrollRevealProps {
+  children: React.ReactNode;
+  delayMs?: number;
+  className?: string;
+}
+
+/**
+ * Fades and lifts its children into view the first time the element
+ * intersects the viewport. Once revealed it stays revealed - scrolling
+ * back up does not re-trigger the animation. Honours
+ * prefers-reduced-motion by rendering the content immediately.
+ */
+export default function ScrollReveal({ children, delayMs = 0, className = '' }: ScrollRevealProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [revealed, setRevealed] = useState(false);
+
+  useEffect(() => {
+    const reduced =
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (reduced) {
+      setRevealed(true);
+      return;
+    }
+
+    const node = ref.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            window.setTimeout(() => setRevealed(true), delayMs);
+            observer.unobserve(entry.target);
+          }
+        }
+      },
+      { threshold: 0.15, rootMargin: '0px 0px -40px 0px' }
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [delayMs]);
+
+  return (
+    <div
+      ref={ref}
+      className={`transition-all duration-700 ease-out ${
+        revealed ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
+      } ${className}`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/pages/QuizList.tsx
+++ b/frontend/src/pages/QuizList.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
 import { getQuizzes } from '../api/client';
 import Hero from '../components/Hero';
+import ScrollReveal from '../components/ScrollReveal';
 import type { QuizSummary } from '../types';
 
 const ALL_CATEGORIES = '__all__';
@@ -75,10 +76,12 @@ export default function QuizList() {
         id="quizzes"
         className="container mx-auto px-4 py-12 max-w-4xl scroll-mt-16"
       >
-        <header className="mb-6">
-          <h2 className="text-2xl font-bold text-gray-900">Available Quizzes</h2>
-          <p className="text-gray-600">Pick one to start practising.</p>
-        </header>
+        <ScrollReveal>
+          <header className="mb-6">
+            <h2 className="text-2xl font-bold text-gray-900">Available Quizzes</h2>
+            <p className="text-gray-600">Pick one to start practising.</p>
+          </header>
+        </ScrollReveal>
 
         {loading ? (
           <div className="flex items-center justify-center py-16">
@@ -154,43 +157,44 @@ export default function QuizList() {
               </div>
             ) : (
               <div className="grid gap-6 md:grid-cols-2">
-                {filtered.map((quiz) => {
+                {filtered.map((quiz, index) => {
                   const locked = !quiz.isPublic && !isAuthenticated;
                   return (
-                    <Link
-                      key={quiz.quizId}
-                      to={locked ? '#' : `/quiz/${quiz.quizId}`}
-                      onClick={locked ? (e) => e.preventDefault() : undefined}
-                      className={`card-hover group ${locked ? 'opacity-50 grayscale pointer-events-auto cursor-not-allowed' : ''}`}
-                      aria-disabled={locked}
-                    >
-                      <div className="flex items-start justify-between mb-3">
-                        <h3 className="text-xl font-semibold text-gray-900 group-hover:text-primary-600 transition-colors">
-                          {quiz.title}
-                        </h3>
-                        <div className="flex items-center gap-2 flex-shrink-0">
-                          {!quiz.isPublic && (
-                            <span title="Login required" className="text-gray-400">
-                              🔒
+                    <ScrollReveal key={quiz.quizId} delayMs={Math.min(index * 60, 360)}>
+                      <Link
+                        to={locked ? '#' : `/quiz/${quiz.quizId}`}
+                        onClick={locked ? (e) => e.preventDefault() : undefined}
+                        className={`card-hover group block ${locked ? 'opacity-50 grayscale pointer-events-auto cursor-not-allowed' : ''}`}
+                        aria-disabled={locked}
+                      >
+                        <div className="flex items-start justify-between mb-3">
+                          <h3 className="text-xl font-semibold text-gray-900 group-hover:text-primary-600 transition-colors">
+                            {quiz.title}
+                          </h3>
+                          <div className="flex items-center gap-2 flex-shrink-0">
+                            {!quiz.isPublic && (
+                              <span title="Login required" className="text-gray-400">
+                                🔒
+                              </span>
+                            )}
+                            <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-primary-100 text-primary-800">
+                              {quiz.questionCount} questions
+                            </span>
+                          </div>
+                        </div>
+                        <p className="text-gray-600 mb-4">{quiz.description}</p>
+                        <div className="flex items-center justify-between">
+                          <span className="text-sm text-gray-500">{quiz.category}</span>
+                          {locked ? (
+                            <span className="text-gray-400 text-sm">Login to access</span>
+                          ) : (
+                            <span className="text-primary-600 group-hover:translate-x-1 transition-transform">
+                              Start Quiz →
                             </span>
                           )}
-                          <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-primary-100 text-primary-800">
-                            {quiz.questionCount} questions
-                          </span>
                         </div>
-                      </div>
-                      <p className="text-gray-600 mb-4">{quiz.description}</p>
-                      <div className="flex items-center justify-between">
-                        <span className="text-sm text-gray-500">{quiz.category}</span>
-                        {locked ? (
-                          <span className="text-gray-400 text-sm">Login to access</span>
-                        ) : (
-                          <span className="text-primary-600 group-hover:translate-x-1 transition-transform">
-                            Start Quiz →
-                          </span>
-                        )}
-                      </div>
-                    </Link>
+                      </Link>
+                    </ScrollReveal>
                   );
                 })}
               </div>


### PR DESCRIPTION
## Summary

Two interactive touches on the home page so it feels less static.

### `SampleQuestion`

A small card next to the headline on desktop (stacked on mobile) that rotates through five hand-picked Laws of the Game questions every ~8 seconds. After ~3.5s the correct answer highlights in green so a visitor sees what the product actually does without taking a quiz. Cards fade between rotations.

Hand-picked sample questions cover: Law 3 (player counts), Law 12 (back-pass handling), Law 9 (deflections off referee), Law 7 (added time).

### `ScrollReveal`

A small wrapper using `IntersectionObserver` that fades and lifts its children into view the first time they intersect the viewport. Used on:

- The "Available Quizzes" section header
- Each quiz card, with a small staggered delay (capped at 360ms) so the grid cascades in rather than flashing all at once

Once revealed, elements stay revealed — scrolling back up doesn't re-trigger.

### Other

The hero is restructured from one centred column to a two-column grid (text + sample card) on `lg+` breakpoints. Mobile keeps the previous stack. Feature bullets sit underneath both, separated by a hairline border.

Both components honour `prefers-reduced-motion`:
- SampleQuestion reveals the answer immediately and stops auto-rotating
- ScrollReveal renders content immediately

## Test plan

- [ ] Hero loads with headline on the left and sample question on the right (desktop)
- [ ] Mobile (`<lg`): hero stacks; sample card fits within the column
- [ ] Sample question rotates every ~8s; green highlight on the correct option appears ~3.5s in; counter "N / 5" updates
- [ ] On scroll, "Available Quizzes" header fades + lifts in; quiz cards cascade in with a small stagger
- [ ] Scroll back up and back down: revealed elements stay revealed (no re-trigger)
- [ ] Enable OS-level "Reduce motion": sample question shows correct answer immediately and doesn't rotate; ScrollReveal content shows immediately
- [ ] Search/filter and locked-card UI still work

https://claude.ai/code/session_012ovSD71NbDWLfcCwfsdtE2

---
_Generated by [Claude Code](https://claude.ai/code/session_012ovSD71NbDWLfcCwfsdtE2)_