### PR TITLE
test(backend): add unit tests for quiz handlers

### DIFF
--- a/backend/src/handlers/getQuestions.test.ts
+++ b/backend/src/handlers/getQuestions.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { buildApiGatewayEvent } from '../lib/test-utils.js';
+import type { BankQuestionItem, ExtractionJobItem } from '../lib/types.js';
+
+const { getExtractionJob, getApprovedQuestionsByJobId, shuffleArray, updateQuestionUsage, verifyToken } =
+  vi.hoisted(() => ({
+    getExtractionJob: vi.fn(),
+    getApprovedQuestionsByJobId: vi.fn(),
+    shuffleArray: vi.fn(<T>(arr: T[]) => [...arr]),
+    updateQuestionUsage: vi.fn().mockResolvedValue(undefined),
+    verifyToken: vi.fn(),
+  }));
+
+vi.mock('../lib/dynamodb.js', () => ({
+  getExtractionJob,
+  getApprovedQuestionsByJobId,
+  shuffleArray,
+  updateQuestionUsage,
+}));
+
+vi.mock('../lib/verifyToken.js', () => ({
+  verifyToken,
+}));
+
+import { handler } from './getQuestions.js';
+
+function publishedJob(overrides: Partial<ExtractionJobItem> = {}): ExtractionJobItem {
+  return {
+    PK: 'JOB#quiz-1',
+    SK: 'METADATA',
+    Type: 'ExtractionJob',
+    jobId: 'quiz-1',
+    s3Key: '',
+    fileName: 'quiz.pdf',
+    status: 'completed',
+    totalQuestions: 5,
+    approvedCount: 5,
+    pendingCount: 0,
+    rejectedCount: 0,
+    duplicateCount: 0,
+    published: true,
+    isPublic: true,
+    createdAt: '2026-05-01T00:00:00.000Z',
+    updatedAt: '2026-05-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function bankQuestion(id: string, law = 'Law 1' as BankQuestionItem['law']): BankQuestionItem {
+  return {
+    PK: `QUESTION#${id}`,
+    SK: 'METADATA',
+    Type: 'BankQuestion',
+    questionId: id,
+    text: `Question ${id}`,
+    options: ['A', 'B', 'C', 'D'],
+    correctAnswer: 0,
+    explanation: 'Explanation',
+    law,
+    lawReference: `${law}.1`,
+    confidence: 0.9,
+    status: 'approved',
+    sourceFile: 'quiz.pdf',
+    jobId: 'quiz-1',
+    hash: `hash-${id}`,
+    createdAt: '2026-05-01T00:00:00.000Z',
+    updatedAt: '2026-05-01T00:00:00.000Z',
+  };
+}
+
+function event(quizId?: string, query: Record<string, string> = {}) {
+  return buildApiGatewayEvent({
+    httpMethod: 'GET',
+    pathParameters: quizId ? { id: quizId } : null,
+    queryStringParameters: Object.keys(query).length ? query : null,
+  });
+}
+
+describe('getQuestions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    shuffleArray.mockImplementation(<T>(arr: T[]) => [...arr]);
+    updateQuestionUsage.mockResolvedValue(undefined);
+  });
+
+  describe('input validation', () => {
+    it('returns 400 when quiz ID is missing', async () => {
+      const res = await handler(buildApiGatewayEvent());
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('returns 400 when limit is non-numeric', async () => {
+      const res = await handler(event('quiz-1', { limit: 'abc' }));
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('returns 400 when limit is 0', async () => {
+      const res = await handler(event('quiz-1', { limit: '0' }));
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('returns 400 when limit exceeds 50', async () => {
+      const res = await handler(event('quiz-1', { limit: '51' }));
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  describe('quiz lookup', () => {
+    it('returns 404 when job does not exist', async () => {
+      getExtractionJob.mockResolvedValue(null);
+      const res = await handler(event('quiz-1'));
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('returns 404 when job is not published', async () => {
+      getExtractionJob.mockResolvedValue(publishedJob({ published: false }));
+      const res = await handler(event('quiz-1'));
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('returns 404 when no approved questions exist', async () => {
+      getExtractionJob.mockResolvedValue(publishedJob({ approvedCount: 0 }));
+      const res = await handler(event('quiz-1'));
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe('auth gate', () => {
+    it('returns 401 for study mode without auth', async () => {
+      getExtractionJob.mockResolvedValue(publishedJob());
+      verifyToken.mockResolvedValue(null);
+      const res = await handler(event('quiz-1', { mode: 'study' }));
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('returns 401 for non-public quiz without auth', async () => {
+      getExtractionJob.mockResolvedValue(publishedJob({ isPublic: false }));
+      verifyToken.mockResolvedValue(null);
+      getApprovedQuestionsByJobId.mockResolvedValue([bankQuestion('q1')]);
+      const res = await handler(event('quiz-1'));
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('proceeds for non-public quiz with valid auth', async () => {
+      getExtractionJob.mockResolvedValue(publishedJob({ isPublic: false }));
+      verifyToken.mockResolvedValue('auth0|123');
+      getApprovedQuestionsByJobId.mockResolvedValue([bankQuestion('q1')]);
+      const res = await handler(event('quiz-1'));
+      expect(res.statusCode).toBe(200);
+    });
+  });
+
+  describe('question response', () => {
+    it('returns questions without answers in standard mode', async () => {
+      getExtractionJob.mockResolvedValue(publishedJob());
+      getApprovedQuestionsByJobId.mockResolvedValue([bankQuestion('q1')]);
+      const res = await handler(event('quiz-1'));
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body[0]).toHaveProperty('questionId', 'q1');
+      expect(body[0]).toHaveProperty('text');
+      expect(body[0]).toHaveProperty('options');
+      expect(body[0]).not.toHaveProperty('correctAnswer');
+      expect(body[0]).not.toHaveProperty('explanation');
+    });
+
+    it('returns questions with answers in study mode', async () => {
+      getExtractionJob.mockResolvedValue(publishedJob());
+      verifyToken.mockResolvedValue('auth0|123');
+      getApprovedQuestionsByJobId.mockResolvedValue([bankQuestion('q1')]);
+      const res = await handler(event('quiz-1', { mode: 'study' }));
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body[0]).toHaveProperty('correctAnswer');
+      expect(body[0]).toHaveProperty('explanation');
+    });
+
+    it('applies limit param', async () => {
+      getExtractionJob.mockResolvedValue(publishedJob());
+      getApprovedQuestionsByJobId.mockResolvedValue([
+        bankQuestion('q1'),
+        bankQuestion('q2'),
+        bankQuestion('q3'),
+      ]);
+      const res = await handler(event('quiz-1', { limit: '2' }));
+      const body = JSON.parse(res.body);
+      expect(body).toHaveLength(2);
+    });
+
+    it('filters questions by lawFilter when set on job', async () => {
+      getExtractionJob.mockResolvedValue(publishedJob({ lawFilter: 'Law 1' }));
+      getApprovedQuestionsByJobId.mockResolvedValue([
+        bankQuestion('q1', 'Law 1'),
+        bankQuestion('q2', 'Law 2'),
+      ]);
+      const res = await handler(event('quiz-1'));
+      const body = JSON.parse(res.body);
+      expect(body.every((q: { questionId: string }) => q.questionId === 'q1')).toBe(true);
+    });
+
+    it('returns 404 when law filter removes all questions', async () => {
+      getExtractionJob.mockResolvedValue(publishedJob({ lawFilter: 'Law 5' }));
+      getApprovedQuestionsByJobId.mockResolvedValue([bankQuestion('q1', 'Law 1')]);
+      const res = await handler(event('quiz-1'));
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  it('returns 500 when DynamoDB throws', async () => {
+    getExtractionJob.mockRejectedValue(new Error('db error'));
+    const res = await handler(event('quiz-1'));
+    expect(res.statusCode).toBe(500);
+  });
+});

--- a/backend/src/handlers/getQuiz.test.ts
+++ b/backend/src/handlers/getQuiz.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { buildApiGatewayEvent } from '../lib/test-utils.js';
+import type { ExtractionJobItem } from '../lib/types.js';
+
+const { getExtractionJob } = vi.hoisted(() => ({
+  getExtractionJob: vi.fn(),
+}));
+
+vi.mock('../lib/dynamodb.js', () => ({
+  getExtractionJob,
+}));
+
+import { handler } from './getQuiz.js';
+
+function publishedJob(overrides: Partial<ExtractionJobItem> = {}): ExtractionJobItem {
+  return {
+    PK: 'JOB#quiz-1',
+    SK: 'METADATA',
+    Type: 'ExtractionJob',
+    jobId: 'quiz-1',
+    s3Key: 'uploads/law-quiz.pdf',
+    fileName: 'law-quiz.pdf',
+    status: 'completed',
+    totalQuestions: 10,
+    approvedCount: 8,
+    pendingCount: 0,
+    rejectedCount: 2,
+    duplicateCount: 0,
+    published: true,
+    isPublic: true,
+    createdAt: '2026-05-01T00:00:00.000Z',
+    updatedAt: '2026-05-02T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function event(quizId?: string) {
+  return buildApiGatewayEvent({
+    httpMethod: 'GET',
+    path: `/quizzes/${quizId ?? 'quiz-1'}`,
+    pathParameters: quizId ? { id: quizId } : null,
+  });
+}
+
+describe('getQuiz', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('input validation', () => {
+    it('returns 400 when quiz ID is missing from path', async () => {
+      const res = await handler(buildApiGatewayEvent({ httpMethod: 'GET' }));
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body).error).toMatch(/quiz id/i);
+    });
+  });
+
+  describe('quiz lookup', () => {
+    it('returns 404 when the job does not exist', async () => {
+      getExtractionJob.mockResolvedValue(null);
+      const res = await handler(event('missing'));
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('returns 404 when the job is not published', async () => {
+      getExtractionJob.mockResolvedValue(publishedJob({ published: false }));
+      const res = await handler(event('quiz-1'));
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('returns 404 when there are no approved questions', async () => {
+      getExtractionJob.mockResolvedValue(publishedJob({ approvedCount: 0 }));
+      const res = await handler(event('quiz-1'));
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe('successful response', () => {
+    it('returns 200 with quiz detail', async () => {
+      getExtractionJob.mockResolvedValue(publishedJob());
+      const res = await handler(event('quiz-1'));
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body).toMatchObject({
+        quizId: 'quiz-1',
+        questionCount: 8,
+        isPublic: true,
+        createdAt: '2026-05-01T00:00:00.000Z',
+        updatedAt: '2026-05-02T00:00:00.000Z',
+      });
+    });
+
+    it('formats the filename as the title', async () => {
+      getExtractionJob.mockResolvedValue(publishedJob({ fileName: 'offside-law-11.pdf' }));
+      const res = await handler(event('quiz-1'));
+      const body = JSON.parse(res.body);
+      expect(body.title).toBe('Offside Law 11');
+    });
+
+    it('includes timeLimitMinutes when set', async () => {
+      getExtractionJob.mockResolvedValue(publishedJob({ timeLimitMinutes: 20 }));
+      const res = await handler(event('quiz-1'));
+      const body = JSON.parse(res.body);
+      expect(body.timeLimitMinutes).toBe(20);
+    });
+
+    it('omits optional fields when not set', async () => {
+      getExtractionJob.mockResolvedValue(
+        publishedJob({ timeLimitMinutes: undefined, lawFilter: undefined })
+      );
+      const res = await handler(event('quiz-1'));
+      const body = JSON.parse(res.body);
+      expect(body).not.toHaveProperty('timeLimitMinutes');
+      expect(body).not.toHaveProperty('lawFilter');
+    });
+  });
+
+  it('returns 500 when DynamoDB throws', async () => {
+    getExtractionJob.mockRejectedValue(new Error('boom'));
+    const res = await handler(event('quiz-1'));
+    expect(res.statusCode).toBe(500);
+  });
+});

--- a/backend/src/handlers/getQuizzes.test.ts
+++ b/backend/src/handlers/getQuizzes.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { buildApiGatewayEvent } from '../lib/test-utils.js';
+import type { ExtractionJobItem } from '../lib/types.js';
+
+const { getPublishedJobs } = vi.hoisted(() => ({
+  getPublishedJobs: vi.fn(),
+}));
+
+vi.mock('../lib/dynamodb.js', () => ({
+  getPublishedJobs,
+}));
+
+import { handler } from './getQuizzes.js';
+
+function publishedJob(overrides: Partial<ExtractionJobItem> = {}): ExtractionJobItem {
+  return {
+    PK: 'JOB#job-1',
+    SK: 'METADATA',
+    Type: 'ExtractionJob',
+    jobId: 'job-1',
+    s3Key: 'uploads/laws-of-the-game.pdf',
+    fileName: 'laws-of-the-game.pdf',
+    status: 'completed',
+    totalQuestions: 20,
+    approvedCount: 15,
+    pendingCount: 0,
+    rejectedCount: 5,
+    duplicateCount: 0,
+    published: true,
+    isPublic: true,
+    createdAt: '2026-05-01T00:00:00.000Z',
+    updatedAt: '2026-05-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('getQuizzes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 200 with empty array when no quizzes exist', async () => {
+    getPublishedJobs.mockResolvedValue([]);
+    const res = await handler(buildApiGatewayEvent());
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual([]);
+  });
+
+  it('returns 200 with quiz summaries from published jobs', async () => {
+    getPublishedJobs.mockResolvedValue([publishedJob()]);
+    const res = await handler(buildApiGatewayEvent());
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({
+      quizId: 'job-1',
+      questionCount: 15,
+      isPublic: true,
+      category: 'Laws of the Game',
+    });
+  });
+
+  it('formats the filename as the quiz title', async () => {
+    getPublishedJobs.mockResolvedValue([publishedJob({ fileName: 'laws-of-the-game-2024.pdf' })]);
+    const res = await handler(buildApiGatewayEvent());
+    const body = JSON.parse(res.body);
+    expect(body[0].title).toBe('Laws Of The Game 2024');
+  });
+
+  it('uses the job description when set', async () => {
+    getPublishedJobs.mockResolvedValue([
+      publishedJob({ description: 'A curated LOTG quiz' }),
+    ]);
+    const res = await handler(buildApiGatewayEvent());
+    const body = JSON.parse(res.body);
+    expect(body[0].description).toBe('A curated LOTG quiz');
+  });
+
+  it('falls back to filename-based description when description is absent', async () => {
+    getPublishedJobs.mockResolvedValue([publishedJob({ fileName: 'lotg.pdf', description: undefined })]);
+    const res = await handler(buildApiGatewayEvent());
+    const body = JSON.parse(res.body);
+    expect(body[0].description).toMatch(/lotg\.pdf/);
+  });
+
+  it('includes optional fields when set on the job', async () => {
+    getPublishedJobs.mockResolvedValue([
+      publishedJob({ timeLimitMinutes: 30, questionsPerAttempt: 10, lawFilter: 'Law 1' }),
+    ]);
+    const res = await handler(buildApiGatewayEvent());
+    const body = JSON.parse(res.body);
+    expect(body[0].timeLimitMinutes).toBe(30);
+    expect(body[0].questionsPerAttempt).toBe(10);
+    expect(body[0].lawFilter).toBe('Law 1');
+  });
+
+  it('returns 500 when DynamoDB throws', async () => {
+    getPublishedJobs.mockRejectedValue(new Error('db error'));
+    const res = await handler(buildApiGatewayEvent());
+    expect(res.statusCode).toBe(500);
+  });
+});

--- a/backend/src/handlers/publishQuiz.test.ts
+++ b/backend/src/handlers/publishQuiz.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { buildApiGatewayEvent } from '../lib/test-utils.js';
+import type { ExtractionJobItem } from '../lib/types.js';
+
+const { getExtractionJob, publishJob, unpublishJob } = vi.hoisted(() => ({
+  getExtractionJob: vi.fn(),
+  publishJob: vi.fn().mockResolvedValue(undefined),
+  unpublishJob: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../lib/dynamodb.js', () => ({
+  getExtractionJob,
+  publishJob,
+  unpublishJob,
+}));
+
+import { handler } from './publishQuiz.js';
+
+function completedJob(overrides: Partial<ExtractionJobItem> = {}): ExtractionJobItem {
+  return {
+    PK: 'JOB#job-1',
+    SK: 'METADATA',
+    Type: 'ExtractionJob',
+    jobId: 'job-1',
+    s3Key: 'uploads/quiz.pdf',
+    fileName: 'quiz.pdf',
+    status: 'completed',
+    totalQuestions: 10,
+    approvedCount: 8,
+    pendingCount: 0,
+    rejectedCount: 2,
+    duplicateCount: 0,
+    published: false,
+    isPublic: false,
+    createdAt: '2026-05-01T00:00:00.000Z',
+    updatedAt: '2026-05-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function event(jobId?: string, body?: unknown) {
+  return buildApiGatewayEvent({
+    httpMethod: 'PUT',
+    pathParameters: jobId ? { id: jobId } : null,
+    body: body !== undefined ? JSON.stringify(body) : null,
+  });
+}
+
+describe('publishQuiz', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    publishJob.mockResolvedValue(undefined);
+    unpublishJob.mockResolvedValue(undefined);
+  });
+
+  describe('input validation', () => {
+    it('returns 400 when job ID is missing', async () => {
+      const res = await handler(buildApiGatewayEvent({ httpMethod: 'PUT' }));
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body).error).toMatch(/job id/i);
+    });
+
+    it('returns 400 when body is not valid JSON', async () => {
+      const res = await handler(
+        buildApiGatewayEvent({
+          httpMethod: 'PUT',
+          pathParameters: { id: 'job-1' },
+          body: 'not json',
+        })
+      );
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  describe('job lookup', () => {
+    it('returns 404 when job does not exist', async () => {
+      getExtractionJob.mockResolvedValue(null);
+      const res = await handler(event('job-1', { publish: true }));
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe('publish constraints', () => {
+    it('returns 400 when trying to publish a non-completed job', async () => {
+      getExtractionJob.mockResolvedValue(completedJob({ status: 'processing' }));
+      const res = await handler(event('job-1', { publish: true }));
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body).error).toMatch(/completed/i);
+    });
+
+    it('returns 400 when trying to publish a job with no approved questions', async () => {
+      getExtractionJob.mockResolvedValue(completedJob({ approvedCount: 0 }));
+      const res = await handler(event('job-1', { publish: true }));
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body).error).toMatch(/no approved/i);
+    });
+  });
+
+  describe('publish', () => {
+    it('publishes a completed job with approved questions', async () => {
+      getExtractionJob.mockResolvedValue(completedJob());
+      const res = await handler(event('job-1', { publish: true }));
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.published).toBe(true);
+      expect(publishJob).toHaveBeenCalledWith('job-1', false);
+    });
+
+    it('publishes as public when isPublic is true', async () => {
+      getExtractionJob.mockResolvedValue(completedJob());
+      const res = await handler(event('job-1', { publish: true, isPublic: true }));
+      expect(res.statusCode).toBe(200);
+      expect(publishJob).toHaveBeenCalledWith('job-1', true);
+    });
+
+    it('publishes with default body when no body is provided', async () => {
+      getExtractionJob.mockResolvedValue(completedJob());
+      const res = await handler(
+        buildApiGatewayEvent({ httpMethod: 'PUT', pathParameters: { id: 'job-1' } })
+      );
+      expect(res.statusCode).toBe(200);
+      expect(publishJob).toHaveBeenCalled();
+    });
+  });
+
+  describe('unpublish', () => {
+    it('unpublishes a published job', async () => {
+      getExtractionJob.mockResolvedValue(completedJob({ published: true }));
+      const res = await handler(event('job-1', { publish: false }));
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.published).toBe(false);
+      expect(unpublishJob).toHaveBeenCalledWith('job-1');
+      expect(publishJob).not.toHaveBeenCalled();
+    });
+  });
+
+  it('returns 500 when DynamoDB throws', async () => {
+    getExtractionJob.mockRejectedValue(new Error('db error'));
+    const res = await handler(event('job-1', { publish: true }));
+    expect(res.statusCode).toBe(500);
+  });
+});

--- a/backend/src/handlers/submitAnswers.test.ts
+++ b/backend/src/handlers/submitAnswers.test.ts
@@ -2,15 +2,20 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { buildApiGatewayEvent } from '../lib/test-utils.js';
 import type { BankQuestionItem, ExtractionJobItem } from '../lib/types.js';
 
-const { getExtractionJob, getBankQuestion, verifyToken } = vi.hoisted(() => ({
-  getExtractionJob: vi.fn(),
-  getBankQuestion: vi.fn(),
-  verifyToken: vi.fn(),
-}));
+const { getExtractionJob, getBankQuestion, saveUserAttempt, updateUserStats, verifyToken } =
+  vi.hoisted(() => ({
+    getExtractionJob: vi.fn(),
+    getBankQuestion: vi.fn(),
+    saveUserAttempt: vi.fn().mockResolvedValue(undefined),
+    updateUserStats: vi.fn().mockResolvedValue(undefined),
+    verifyToken: vi.fn(),
+  }));
 
 vi.mock('../lib/dynamodb.js', () => ({
   getExtractionJob,
   getBankQuestion,
+  saveUserAttempt,
+  updateUserStats,
 }));
 
 vi.mock('../lib/verifyToken.js', () => ({


### PR DESCRIPTION
## Summary

Closes #48.

- Adds vitest test suites for 4 previously untested Lambda handlers: `getQuizzes`, `getQuiz`, `getQuestions`, and `publishQuiz`
- Updates `submitAnswers.test.ts` mock to include the new DynamoDB functions added in the user-progress branch

## Test coverage added

| Handler | Tests |
|---------|-------|
| `getQuizzes` | Empty list, title formatting from filename, description fallback, optional fields (timeLimitMinutes, lawFilter, questionsPerAttempt), 500 on DB error |
| `getQuiz` | Missing ID → 400, not found → 404, unpublished → 404, zero approved → 404, title formatting, optional field inclusion/omission, 500 on DB error |
| `getQuestions` | Invalid limit → 400, quiz not found → 404, study-mode auth gate, private-quiz auth gate, answer hiding (standard vs study mode), limit param, law filter, 500 on DB error |
| `publishQuiz` | Missing ID → 400, invalid JSON → 400, job not found → 404, non-completed → 400, zero approved → 400, publish with isPublic flag, default body, unpublish, 500 on DB error |

**Total: 65 tests, all passing.**

## How to test

```bash
cd backend && npm test
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGjm7Zfe2gR1fAqEdDwF8J)_