### PR TITLE
feat(backend): user progress tracking — store attempts and aggregate stats

### DIFF
--- a/.infra/modules/backend/main.tf
+++ b/.infra/modules/backend/main.tf
@@ -20,6 +20,8 @@ locals {
     "updateJobMetadata",
     "removeJobQuestion",
     "authorize",
+    "getMyAttempts",
+    "getMyStats",
   ]
 }
 
@@ -69,6 +71,8 @@ resource "aws_iam_role_policy" "lambda_dynamodb" {
         Effect = "Allow"
         Action = [
           "dynamodb:GetItem",
+          "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
           "dynamodb:Query",
           "dynamodb:Scan"
         ]
@@ -431,6 +435,8 @@ resource "aws_api_gateway_deployment" "this" {
     aws_api_gateway_integration.add_manual_question,
     aws_api_gateway_integration.update_job_metadata,
     aws_api_gateway_integration.remove_job_question,
+    aws_api_gateway_integration.get_my_attempts,
+    aws_api_gateway_integration.get_my_stats,
   ]
 
   lifecycle {
@@ -458,6 +464,9 @@ resource "aws_api_gateway_deployment" "this" {
       aws_api_gateway_resource.admin_job_questions.id,
       aws_api_gateway_resource.admin_job_metadata.id,
       aws_api_gateway_resource.admin_job_question_id.id,
+      aws_api_gateway_resource.me.id,
+      aws_api_gateway_resource.me_attempts.id,
+      aws_api_gateway_resource.me_stats.id,
       [for r in aws_api_gateway_gateway_response.cors : r.id],
     ]))
   }
@@ -1461,6 +1470,153 @@ resource "aws_lambda_permission" "publish_quiz" {
   statement_id  = "AllowAPIGatewayInvoke"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.publish_quiz.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
+}
+
+# ============================================================================
+# User Progress Tracking (Issue #47)
+# Lambda functions: getMyAttempts, getMyStats
+# Routes: GET /me/attempts, GET /me/stats
+# ============================================================================
+
+resource "aws_lambda_function" "get_my_attempts" {
+  filename         = "${path.module}/../../../backend/dist/getMyAttempts.zip"
+  function_name    = "${var.project_name}-${var.environment}-getMyAttempts"
+  role             = aws_iam_role.lambda.arn
+  handler          = "index.handler"
+  runtime          = "nodejs24.x"
+  timeout          = 10
+  memory_size      = 256
+  source_code_hash = fileexists("${path.module}/../../../backend/dist/getMyAttempts.zip") ? filebase64sha256("${path.module}/../../../backend/dist/getMyAttempts.zip") : null
+
+  environment {
+    variables = {
+      TABLE_NAME   = var.dynamodb_table_name
+      AUTH0_DOMAIN = var.auth0_domain
+      NODE_ENV     = var.environment
+    }
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-getMyAttempts"
+  }
+}
+
+resource "aws_lambda_function" "get_my_stats" {
+  filename         = "${path.module}/../../../backend/dist/getMyStats.zip"
+  function_name    = "${var.project_name}-${var.environment}-getMyStats"
+  role             = aws_iam_role.lambda.arn
+  handler          = "index.handler"
+  runtime          = "nodejs24.x"
+  timeout          = 10
+  memory_size      = 256
+  source_code_hash = fileexists("${path.module}/../../../backend/dist/getMyStats.zip") ? filebase64sha256("${path.module}/../../../backend/dist/getMyStats.zip") : null
+
+  environment {
+    variables = {
+      TABLE_NAME   = var.dynamodb_table_name
+      AUTH0_DOMAIN = var.auth0_domain
+      NODE_ENV     = var.environment
+    }
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-getMyStats"
+  }
+}
+
+# /me resource
+resource "aws_api_gateway_resource" "me" {
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  parent_id   = aws_api_gateway_rest_api.this.root_resource_id
+  path_part   = "me"
+}
+
+# /me/attempts resource
+resource "aws_api_gateway_resource" "me_attempts" {
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  parent_id   = aws_api_gateway_resource.me.id
+  path_part   = "attempts"
+}
+
+# /me/stats resource
+resource "aws_api_gateway_resource" "me_stats" {
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  parent_id   = aws_api_gateway_resource.me.id
+  path_part   = "stats"
+}
+
+# GET /me/attempts
+resource "aws_api_gateway_method" "get_my_attempts" {
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  resource_id   = aws_api_gateway_resource.me_attempts.id
+  http_method   = "GET"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "get_my_attempts" {
+  rest_api_id             = aws_api_gateway_rest_api.this.id
+  resource_id             = aws_api_gateway_resource.me_attempts.id
+  http_method             = aws_api_gateway_method.get_my_attempts.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.get_my_attempts.invoke_arn
+}
+
+# GET /me/stats
+resource "aws_api_gateway_method" "get_my_stats" {
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  resource_id   = aws_api_gateway_resource.me_stats.id
+  http_method   = "GET"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "get_my_stats" {
+  rest_api_id             = aws_api_gateway_rest_api.this.id
+  resource_id             = aws_api_gateway_resource.me_stats.id
+  http_method             = aws_api_gateway_method.get_my_stats.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.get_my_stats.invoke_arn
+}
+
+module "cors_me" {
+  source  = "squidfunk/api-gateway-enable-cors/aws"
+  version = "0.3.3"
+
+  api_id          = aws_api_gateway_rest_api.this.id
+  api_resource_id = aws_api_gateway_resource.me.id
+}
+
+module "cors_me_attempts" {
+  source  = "squidfunk/api-gateway-enable-cors/aws"
+  version = "0.3.3"
+
+  api_id          = aws_api_gateway_rest_api.this.id
+  api_resource_id = aws_api_gateway_resource.me_attempts.id
+}
+
+module "cors_me_stats" {
+  source  = "squidfunk/api-gateway-enable-cors/aws"
+  version = "0.3.3"
+
+  api_id          = aws_api_gateway_rest_api.this.id
+  api_resource_id = aws_api_gateway_resource.me_stats.id
+}
+
+resource "aws_lambda_permission" "get_my_attempts" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.get_my_attempts.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
+}
+
+resource "aws_lambda_permission" "get_my_stats" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.get_my_stats.function_name
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
 }

--- a/backend/src/handlers/getMyAttempts.ts
+++ b/backend/src/handlers/getMyAttempts.ts
@@ -1,0 +1,71 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult, UserAttempt } from '../lib/types.js';
+import { getUserAttempts } from '../lib/dynamodb.js';
+import { successResponse, errorResponse } from '../lib/response.js';
+import { verifyToken } from '../lib/verifyToken.js';
+
+/**
+ * GET /me/attempts
+ * Returns paginated quiz attempt history for the authenticated user.
+ * Query params: limit (default 20, max 50), cursor (pagination token)
+ */
+export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  console.log('Event:', JSON.stringify(event, null, 2));
+
+  const userId = await verifyToken(
+    event.headers?.Authorization || event.headers?.authorization
+  );
+
+  if (!userId) {
+    return errorResponse('Authentication required', 401);
+  }
+
+  const limitParam = event.queryStringParameters?.limit;
+  const cursor = event.queryStringParameters?.cursor;
+
+  let limit = 20;
+  if (limitParam) {
+    limit = parseInt(limitParam, 10);
+    if (isNaN(limit) || limit < 1 || limit > 50) {
+      return errorResponse('limit must be between 1 and 50', 400);
+    }
+  }
+
+  let lastEvaluatedKey: Record<string, unknown> | undefined;
+  if (cursor) {
+    try {
+      lastEvaluatedKey = JSON.parse(Buffer.from(cursor, 'base64').toString('utf-8'));
+    } catch {
+      return errorResponse('Invalid cursor', 400);
+    }
+  }
+
+  try {
+    const { items, lastEvaluatedKey: nextKey } = await getUserAttempts(
+      userId,
+      limit,
+      lastEvaluatedKey
+    );
+
+    const attempts: UserAttempt[] = items.map((item) => ({
+      attemptId: item.SK,
+      quizId: item.quizId,
+      score: item.score,
+      total: item.total,
+      percentage: item.percentage,
+      questionResults: item.questionResults,
+      createdAt: item.createdAt,
+    }));
+
+    const nextCursor = nextKey
+      ? Buffer.from(JSON.stringify(nextKey)).toString('base64')
+      : undefined;
+
+    return successResponse({
+      attempts,
+      ...(nextCursor && { nextCursor }),
+    });
+  } catch (error) {
+    console.error('Error fetching attempts:', error);
+    return errorResponse('Failed to fetch attempts', 500);
+  }
+}

--- a/backend/src/handlers/getMyStats.ts
+++ b/backend/src/handlers/getMyStats.ts
@@ -1,0 +1,46 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult, UserStats } from '../lib/types.js';
+import { getUserStats } from '../lib/dynamodb.js';
+import { successResponse, errorResponse } from '../lib/response.js';
+import { verifyToken } from '../lib/verifyToken.js';
+
+/**
+ * GET /me/stats
+ * Returns aggregated quiz stats for the authenticated user.
+ */
+export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  console.log('Event:', JSON.stringify(event, null, 2));
+
+  const userId = await verifyToken(
+    event.headers?.Authorization || event.headers?.authorization
+  );
+
+  if (!userId) {
+    return errorResponse('Authentication required', 401);
+  }
+
+  try {
+    const statsItem = await getUserStats(userId);
+
+    if (!statsItem) {
+      const empty: UserStats = {
+        totalAttempts: 0,
+        averageScore: 0,
+        bestScore: 0,
+        byLaw: {},
+      };
+      return successResponse(empty);
+    }
+
+    const stats: UserStats = {
+      totalAttempts: statsItem.totalAttempts,
+      averageScore: statsItem.averageScore,
+      bestScore: statsItem.bestScore,
+      byLaw: statsItem.byLaw,
+    };
+
+    return successResponse(stats);
+  } catch (error) {
+    console.error('Error fetching stats:', error);
+    return errorResponse('Failed to fetch stats', 500);
+  }
+}

--- a/backend/src/handlers/submitAnswers.test.ts
+++ b/backend/src/handlers/submitAnswers.test.ts
@@ -2,15 +2,20 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { buildApiGatewayEvent } from '../lib/test-utils.js';
 import type { BankQuestionItem, ExtractionJobItem } from '../lib/types.js';
 
-const { getExtractionJob, getBankQuestion, verifyToken } = vi.hoisted(() => ({
-  getExtractionJob: vi.fn(),
-  getBankQuestion: vi.fn(),
-  verifyToken: vi.fn(),
-}));
+const { getExtractionJob, getBankQuestion, saveUserAttempt, updateUserStats, verifyToken } =
+  vi.hoisted(() => ({
+    getExtractionJob: vi.fn(),
+    getBankQuestion: vi.fn(),
+    saveUserAttempt: vi.fn().mockResolvedValue(undefined),
+    updateUserStats: vi.fn().mockResolvedValue(undefined),
+    verifyToken: vi.fn(),
+  }));
 
 vi.mock('../lib/dynamodb.js', () => ({
   getExtractionJob,
   getBankQuestion,
+  saveUserAttempt,
+  updateUserStats,
 }));
 
 vi.mock('../lib/verifyToken.js', () => ({

--- a/backend/src/handlers/submitAnswers.ts
+++ b/backend/src/handlers/submitAnswers.ts
@@ -1,9 +1,16 @@
+import { ulid } from 'ulid';
 import type {
   APIGatewayProxyEvent,
   APIGatewayProxyResult,
   BankQuestionItem,
+  PerQuestionResult,
 } from '../lib/types.js';
-import { getExtractionJob, getBankQuestion } from '../lib/dynamodb.js';
+import {
+  getExtractionJob,
+  getBankQuestion,
+  saveUserAttempt,
+  updateUserStats,
+} from '../lib/dynamodb.js';
 import { successResponse, errorResponse } from '../lib/response.js';
 import { verifyToken } from '../lib/verifyToken.js';
 
@@ -36,7 +43,9 @@ interface SubmitAnswersResponse {
 
 /**
  * POST /quizzes/{id}/submit
- * Submits quiz answers and returns results with correct answers
+ * Submits quiz answers and returns results with correct answers.
+ * If the request carries a valid auth token, the attempt is persisted for
+ * the user's progress history.
  */
 export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
   console.log('Event:', JSON.stringify(event, null, 2));
@@ -70,29 +79,27 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
       return errorResponse('Quiz not found', 404);
     }
 
-    // Enforce auth for non-public quizzes
-    if (!job.isPublic) {
-      const userId = await verifyToken(
-        event.headers?.Authorization || event.headers?.authorization
-      );
-      if (!userId) {
-        return errorResponse('Authentication required', 401);
-      }
+    // Try to identify the caller — required for private quizzes, optional for public
+    const userId = await verifyToken(
+      event.headers?.Authorization || event.headers?.authorization
+    );
+
+    if (!job.isPublic && !userId) {
+      return errorResponse('Authentication required', 401);
     }
 
     // Fetch each question and build results
     const results: QuestionResult[] = [];
+    const perQuestionResults: PerQuestionResult[] = [];
 
     for (const answer of request.answers) {
       const question = await getBankQuestion(answer.questionId);
 
       if (!question) {
-        // Skip questions that don't exist
         console.warn(`Question not found: ${answer.questionId}`);
         continue;
       }
 
-      // Verify question belongs to this quiz
       if (question.jobId !== quizId) {
         console.warn(`Question ${answer.questionId} does not belong to quiz ${quizId}`);
         continue;
@@ -110,6 +117,13 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
         explanation: question.explanation || 'No explanation available.',
         lawReference: question.lawReference || question.law || 'N/A',
       });
+
+      perQuestionResults.push({
+        questionId: question.questionId,
+        selectedOption: answer.selectedOption,
+        isCorrect,
+        law: question.law,
+      });
     }
 
     const correctCount = results.filter((r) => r.isCorrect).length;
@@ -124,6 +138,29 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
         percentage,
       },
     };
+
+    // Persist the attempt for authenticated users (fire-and-forget — do not delay response)
+    if (userId && totalCount > 0) {
+      const now = new Date().toISOString();
+      const attemptSK = `ATTEMPT#${now}#${quizId}`;
+      Promise.all([
+        saveUserAttempt({
+          PK: `USER#${userId}`,
+          SK: attemptSK,
+          Type: 'UserAttempt',
+          userId,
+          quizId,
+          score: correctCount,
+          total: totalCount,
+          percentage,
+          questionResults: perQuestionResults,
+          createdAt: now,
+        }),
+        updateUserStats(userId, percentage, perQuestionResults),
+      ]).catch((err) => {
+        console.error('Error persisting user attempt:', err);
+      });
+    }
 
     return successResponse(response);
   } catch (error) {

--- a/backend/src/lib/dynamodb.ts
+++ b/backend/src/lib/dynamodb.ts
@@ -14,6 +14,10 @@ import type {
   ExtractionJobItem,
   QuestionStatus,
   Law,
+  UserAttemptItem,
+  UserStatsItem,
+  PerQuestionResult,
+  LawStats,
 } from './types.js';
 
 const client = new DynamoDBClient({});
@@ -493,3 +497,104 @@ export async function updateQuestionUsage(questionIds: string[]): Promise<void> 
     )
   );
 }
+
+// ============================================================================
+// User Progress Tracking
+// ============================================================================
+
+/**
+ * Save a quiz attempt for a user
+ */
+export async function saveUserAttempt(attempt: UserAttemptItem): Promise<void> {
+  await docClient.send(new PutCommand({ TableName: TABLE_NAME, Item: attempt }));
+}
+
+/**
+ * Get paginated quiz attempts for a user, most recent first
+ */
+export async function getUserAttempts(
+  userId: string,
+  limit = 20,
+  lastEvaluatedKey?: Record<string, unknown>
+): Promise<{ items: UserAttemptItem[]; lastEvaluatedKey?: Record<string, unknown> }> {
+  const result = await docClient.send(
+    new QueryCommand({
+      TableName: TABLE_NAME,
+      KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+      ExpressionAttributeValues: {
+        ':pk': `USER#${userId}`,
+        ':prefix': 'ATTEMPT#',
+      },
+      ScanIndexForward: false,
+      Limit: limit,
+      ...(lastEvaluatedKey && { ExclusiveStartKey: lastEvaluatedKey }),
+    })
+  );
+
+  return {
+    items: (result.Items || []) as UserAttemptItem[],
+    lastEvaluatedKey: result.LastEvaluatedKey as Record<string, unknown> | undefined,
+  };
+}
+
+/**
+ * Get aggregated stats for a user
+ */
+export async function getUserStats(userId: string): Promise<UserStatsItem | null> {
+  const result = await docClient.send(
+    new GetCommand({
+      TableName: TABLE_NAME,
+      Key: { PK: `USER#${userId}`, SK: 'STATS' },
+    })
+  );
+  return (result.Item as UserStatsItem) || null;
+}
+
+/**
+ * Update (or create) aggregated stats for a user after a new attempt.
+ * Reads the existing stats, merges in the new attempt, then writes back.
+ */
+export async function updateUserStats(
+  userId: string,
+  percentage: number,
+  questionResults: PerQuestionResult[]
+): Promise<void> {
+  const now = new Date().toISOString();
+  const existing = await getUserStats(userId);
+
+  const totalAttempts = (existing?.totalAttempts ?? 0) + 1;
+  const prevAvg = existing?.averageScore ?? 0;
+  const averageScore = Math.round(
+    (prevAvg * (totalAttempts - 1) + percentage) / totalAttempts
+  );
+  const bestScore = Math.max(existing?.bestScore ?? 0, percentage);
+
+  const byLaw: Partial<Record<string, LawStats>> = { ...(existing?.byLaw ?? {}) };
+  for (const qr of questionResults) {
+    const key = qr.law;
+    const prev = byLaw[key];
+    const attempts = (prev?.attempts ?? 0) + 1;
+    const totalCorrect = (prev?.totalCorrect ?? 0) + (qr.isCorrect ? 1 : 0);
+    byLaw[key] = {
+      attempts,
+      totalCorrect,
+      avgScore: Math.round((totalCorrect / attempts) * 100),
+      lastAttempt: now,
+    };
+  }
+
+  const stats: UserStatsItem = {
+    PK: `USER#${userId}`,
+    SK: 'STATS',
+    Type: 'UserStats',
+    userId,
+    totalAttempts,
+    averageScore,
+    bestScore,
+    byLaw: byLaw as UserStatsItem['byLaw'],
+    updatedAt: now,
+  };
+
+  await docClient.send(new PutCommand({ TableName: TABLE_NAME, Item: stats }));
+}
+

--- a/backend/src/lib/types.ts
+++ b/backend/src/lib/types.ts
@@ -199,6 +199,67 @@ export interface ExtractedQuestion {
   confidence: number;
 }
 
+// ============================================================================
+// User Progress Tracking (Issue #47)
+// ============================================================================
+
+export interface PerQuestionResult {
+  questionId: string;
+  selectedOption: number;
+  isCorrect: boolean;
+  law: Law;
+}
+
+export interface UserAttemptItem {
+  PK: string; // USER#{userId}
+  SK: string; // ATTEMPT#{createdAt}#{quizId}
+  Type: 'UserAttempt';
+  userId: string;
+  quizId: string;
+  score: number;
+  total: number;
+  percentage: number;
+  questionResults: PerQuestionResult[];
+  createdAt: string;
+}
+
+export interface LawStats {
+  attempts: number;
+  totalCorrect: number;
+  avgScore: number;
+  lastAttempt: string;
+}
+
+export interface UserStatsItem {
+  PK: string; // USER#{userId}
+  SK: string; // STATS
+  Type: 'UserStats';
+  userId: string;
+  totalAttempts: number;
+  averageScore: number;
+  bestScore: number;
+  byLaw: Partial<Record<Law, LawStats>>;
+  updatedAt: string;
+}
+
+// API response types for user progress
+export interface UserAttempt {
+  attemptId: string;
+  quizId: string;
+  score: number;
+  total: number;
+  percentage: number;
+  questionResults: PerQuestionResult[];
+  createdAt: string;
+}
+
+export interface UserStats {
+  totalAttempts: number;
+  averageScore: number;
+  bestScore: number;
+  byLaw: Partial<Record<Law, LawStats>>;
+}
+
 // Lambda event types
 export interface APIGatewayProxyEvent {
   httpMethod: string;


### PR DESCRIPTION
## Summary

Closes #47.

- Authenticated users' quiz submissions are now persisted in DynamoDB
- Two new endpoints expose attempt history and aggregated stats per user
- Unauthenticated submissions continue to work exactly as before

## Changes

### Data model (no new GSIs required)

| Item | PK | SK |
|------|----|----|
| `UserAttemptItem` | `USER#{userId}` | `ATTEMPT#{createdAt}#{quizId}` |
| `UserStatsItem` | `USER#{userId}` | `STATS` |

Per-attempt data stored: score, total, percentage, and per-question results (questionId, selectedOption, isCorrect, law). Stats are updated on every submission: totalAttempts, averageScore, bestScore, and a per-law breakdown with attempt count, running average, and last attempt timestamp.

### Backend

- **`types.ts`**: `UserAttemptItem`, `UserStatsItem`, `PerQuestionResult`, `LawStats`, and API response types `UserAttempt` / `UserStats`
- **`dynamodb.ts`**: `saveUserAttempt`, `getUserAttempts` (paginated), `getUserStats`, `updateUserStats` (read-modify-write for stats)
- **`submitAnswers.ts`**: extracts `userId` from the JWT (already present for private-quiz auth); if valid, fires-and-forgets attempt persistence — the response is not delayed
- **`getMyAttempts.ts`** (new): `GET /me/attempts` — paginated via opaque base64 cursor, default 20 results, max 50
- **`getMyStats.ts`** (new): `GET /me/stats` — returns zero-state object when user has no attempts yet

### Infrastructure

- `lambda_functions` list updated (CloudWatch log groups with 3-day retention)
- `lambda` IAM role policy: added `PutItem` and `UpdateItem` (required for `submitAnswers` to persist attempts and for `updateQuestionUsage` which was already calling `UpdateItem`)
- Lambda resources: `getMyAttempts` and `getMyStats` using the public lambda role + `AUTH0_DOMAIN` env var
- API Gateway: `/me`, `/me/attempts`, `/me/stats` resources with GET methods, `AWS_PROXY` integrations, CORS modules, Lambda permissions
- Deployment `depends_on` and `triggers` updated for the new integrations

## How to test

```bash
# All 65 backend tests pass
cd backend && npm test

# Terraform
cd .infra && terraform validate && terraform plan
```

## Notes

- Stats are computed in-process (read existing stats → merge → write back). At quiz-taking scale this is fine; a dedicated aggregation Lambda can be added later if needed (see #52).
- The `/me/attempts` cursor is a base64-encoded DynamoDB `LastEvaluatedKey` — opaque to callers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGjm7Zfe2gR1fAqEdDwF8J)_