### PR TITLE
fix(ci): add getMyAttempts and getMyStats to build and deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -242,6 +242,8 @@ jobs:
       lambda_create_manual_job: ${{ steps.tf-output.outputs.lambda_create_manual_job }}
       lambda_add_manual_question: ${{ steps.tf-output.outputs.lambda_add_manual_question }}
       lambda_authorize: ${{ steps.tf-output.outputs.lambda_authorize }}
+      lambda_get_my_attempts: ${{ steps.tf-output.outputs.lambda_get_my_attempts }}
+      lambda_get_my_stats: ${{ steps.tf-output.outputs.lambda_get_my_stats }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -281,6 +283,8 @@ jobs:
           echo "lambda_create_manual_job=$(terraform output -json lambda_function_names | jq -r '.create_manual_job')" >> $GITHUB_OUTPUT
           echo "lambda_add_manual_question=$(terraform output -json lambda_function_names | jq -r '.add_manual_question')" >> $GITHUB_OUTPUT
           echo "lambda_authorize=$(terraform output -json lambda_function_names | jq -r '.authorize')" >> $GITHUB_OUTPUT
+          echo "lambda_get_my_attempts=$(terraform output -json lambda_function_names | jq -r '.get_my_attempts')" >> $GITHUB_OUTPUT
+          echo "lambda_get_my_stats=$(terraform output -json lambda_function_names | jq -r '.get_my_stats')" >> $GITHUB_OUTPUT
 
   # Deploy Backend - uses pre-built artifacts
   deploy-backend:
@@ -403,6 +407,20 @@ jobs:
           aws lambda update-function-code \
             --function-name ${{ needs.get-outputs.outputs.lambda_authorize }} \
             --zip-file fileb://backend/dist/authorize.zip
+
+      - name: Update Lambda - getMyAttempts
+        if: needs.get-outputs.outputs.lambda_get_my_attempts != '' && needs.get-outputs.outputs.lambda_get_my_attempts != 'null'
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ needs.get-outputs.outputs.lambda_get_my_attempts }} \
+            --zip-file fileb://backend/dist/getMyAttempts.zip
+
+      - name: Update Lambda - getMyStats
+        if: needs.get-outputs.outputs.lambda_get_my_stats != '' && needs.get-outputs.outputs.lambda_get_my_stats != 'null'
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ needs.get-outputs.outputs.lambda_get_my_stats }} \
+            --zip-file fileb://backend/dist/getMyStats.zip
 
   # Build and Deploy Frontend
   deploy-frontend:

--- a/.infra/modules/backend/outputs.tf
+++ b/.infra/modules/backend/outputs.tf
@@ -32,6 +32,8 @@ output "lambda_function_names" {
     update_job_metadata    = aws_lambda_function.update_job_metadata.function_name
     remove_job_question    = aws_lambda_function.remove_job_question.function_name
     authorize              = aws_lambda_function.authorize.function_name
+    get_my_attempts        = aws_lambda_function.get_my_attempts.function_name
+    get_my_stats           = aws_lambda_function.get_my_stats.function_name
   }
 }
 
@@ -54,6 +56,8 @@ output "lambda_function_arns" {
     update_job_metadata    = aws_lambda_function.update_job_metadata.arn
     remove_job_question    = aws_lambda_function.remove_job_question.arn
     authorize              = aws_lambda_function.authorize.arn
+    get_my_attempts        = aws_lambda_function.get_my_attempts.arn
+    get_my_stats           = aws_lambda_function.get_my_stats.arn
   }
 }
 

--- a/backend/build.js
+++ b/backend/build.js
@@ -31,6 +31,9 @@ const handlers = [
   'removeJobQuestion',
   // Auth
   'authorize',
+  // User progress
+  'getMyAttempts',
+  'getMyStats',
 ];
 
 async function buildHandler(handlerName) {


### PR DESCRIPTION
## Summary

Fixes the Terraform apply failure introduced when PR #69 added the `getMyAttempts` and `getMyStats` Lambda handlers but did not update the build pipeline or deployment workflow.

- `backend/build.js`: add `getMyAttempts` and `getMyStats` to the handlers array so their ZIP artifacts are produced during CI
- `.infra/modules/backend/outputs.tf`: expose `get_my_attempts` and `get_my_stats` in the `lambda_function_names` output map
- `.github/workflows/deploy.yml`: capture both new Lambda names in `get-outputs` and add `Update Lambda` deploy steps for each

## Test plan

- [ ] Confirm Terraform plan no longer errors with "no such file or directory" for the ZIP paths
- [ ] Confirm `build-backend` job produces `getMyAttempts.zip` and `getMyStats.zip` in artifacts
- [ ] Confirm `deploy-backend` updates both new Lambda functions after a merge to main

https://claude.ai/code/session_01SGjm7Zfe2gR1fAqEdDwF8J

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGjm7Zfe2gR1fAqEdDwF8J)_