### PR TITLE
feat(frontend): user profile and quiz history pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,8 @@ import AdminAddQuestion from './pages/admin/AddQuestion';
 import AdminManageQuizzes from './pages/admin/ManageQuizzes';
 import AdminEditQuiz from './pages/admin/EditQuiz';
 import AdminQuizQuestions from './pages/admin/QuizQuestions';
+import ProfilePage from './pages/ProfilePage';
+import HistoryPage from './pages/HistoryPage';
 
 export default function App() {
   return (
@@ -25,6 +27,8 @@ export default function App() {
         <Route path="/" element={<QuizList />} />
         <Route path="/quiz/:quizId" element={<QuizTake />} />
         <Route path="/quiz/:quizId/results" element={<QuizResults />} />
+        <Route path="/profile" element={<ProfilePage />} />
+        <Route path="/history" element={<HistoryPage />} />
       </Route>
 
       {/* Protected admin routes */}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -18,6 +18,8 @@ import type {
   AddManualQuestionResponse,
   SubmitAnswersResponse,
   UpdateQuizMetadataRequest,
+  UserAttemptsResponse,
+  UserStats,
 } from '../types';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
@@ -254,6 +256,27 @@ export async function updateQuizMetadata(
     { method: 'PUT', body: JSON.stringify(updates) },
     token
   );
+}
+
+// User progress endpoints
+export async function getMyAttempts(
+  token: string,
+  limit?: number,
+  cursor?: string
+): Promise<UserAttemptsResponse> {
+  const params = new URLSearchParams();
+  if (limit !== undefined) params.set('limit', limit.toString());
+  if (cursor) params.set('cursor', cursor);
+  const query = params.toString();
+  return fetchAPI<UserAttemptsResponse>(
+    `/me/attempts${query ? `?${query}` : ''}`,
+    undefined,
+    token
+  );
+}
+
+export async function getMyStats(token: string): Promise<UserStats> {
+  return fetchAPI<UserStats>('/me/stats', undefined, token);
 }
 
 export async function removeQuizQuestion(

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -22,6 +22,12 @@ export default function Navbar() {
               <div className="h-8 w-8 animate-pulse bg-gray-200 rounded-full" />
             ) : isAuthenticated ? (
               <>
+                <Link
+                  to="/profile"
+                  className="px-3 py-2 text-sm font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-md transition-colors"
+                >
+                  My Progress
+                </Link>
                 {isAdmin && (
                   <Link
                     to="/admin"

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth0 } from '@auth0/auth0-react';
+import { useAccessToken } from '../hooks/useAccessToken';
+import { getMyAttempts } from '../api/client';
+import type { UserAttempt } from '../types';
+
+const PAGE_SIZE = 20;
+
+function scoreColour(pct: number): string {
+  if (pct >= 90) return 'text-green-600';
+  if (pct >= 70) return 'text-blue-600';
+  if (pct >= 50) return 'text-amber-600';
+  return 'text-red-600';
+}
+
+function scoreBadgeBg(pct: number): string {
+  if (pct >= 90) return 'bg-green-100';
+  if (pct >= 70) return 'bg-blue-100';
+  if (pct >= 50) return 'bg-amber-100';
+  return 'bg-red-100';
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export default function HistoryPage() {
+  const { isAuthenticated, isLoading: authLoading, loginWithRedirect } = useAuth0();
+  const { token, loading: tokenLoading } = useAccessToken();
+  const [attempts, setAttempts] = useState<UserAttempt[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | undefined>(undefined);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadPage = useCallback(
+    async (cursor?: string) => {
+      if (!token) return;
+      const isFirst = !cursor;
+      if (isFirst) setLoading(true);
+      else setLoadingMore(true);
+
+      try {
+        const data = await getMyAttempts(token, PAGE_SIZE, cursor);
+        setAttempts((prev) => (isFirst ? data.attempts : [...prev, ...data.attempts]));
+        setNextCursor(data.nextCursor);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load history');
+      } finally {
+        if (isFirst) setLoading(false);
+        else setLoadingMore(false);
+      }
+    },
+    [token]
+  );
+
+  useEffect(() => {
+    if (token) loadPage();
+  }, [token, loadPage]);
+
+  if (authLoading || tokenLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600" />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <div className="card max-w-md text-center">
+          <h2 className="text-xl font-bold text-gray-900 mb-2">Sign in to view your history</h2>
+          <p className="text-gray-600 mb-4">All your past quiz attempts will appear here.</p>
+          <button onClick={() => loginWithRedirect()} className="btn btn-primary">
+            Log In
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="card max-w-md mx-auto text-center">
+          <h2 className="text-xl font-bold text-red-600 mb-2">Error</h2>
+          <p className="text-gray-600">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-3xl">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Quiz History</h1>
+        <Link to="/profile" className="btn btn-secondary text-sm">
+          Back to Profile
+        </Link>
+      </div>
+
+      {attempts.length === 0 ? (
+        <div className="card text-center text-gray-500">
+          <p className="mb-4">No quiz attempts yet.</p>
+          <Link to="/" className="btn btn-primary">
+            Browse Quizzes
+          </Link>
+        </div>
+      ) : (
+        <>
+          <div className="space-y-3">
+            {attempts.map((attempt) => (
+              <div key={attempt.attemptId} className="card flex items-center justify-between gap-4">
+                <div className="min-w-0">
+                  <div className="text-xs text-gray-400">{formatDate(attempt.createdAt)}</div>
+                  <div className="text-sm text-gray-600 mt-0.5">
+                    {attempt.score} / {attempt.total} correct
+                  </div>
+                </div>
+                <div
+                  className={`shrink-0 px-3 py-1 rounded-full text-sm font-bold ${scoreBadgeBg(attempt.percentage)} ${scoreColour(attempt.percentage)}`}
+                >
+                  {attempt.percentage.toFixed(0)}%
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {nextCursor && (
+            <div className="mt-6 text-center">
+              <button
+                onClick={() => loadPage(nextCursor)}
+                disabled={loadingMore}
+                className="btn btn-secondary"
+              >
+                {loadingMore ? 'Loading…' : 'Load More'}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth0 } from '@auth0/auth0-react';
+import { useAccessToken } from '../hooks/useAccessToken';
+import { getMyStats } from '../api/client';
+import type { UserStats } from '../types';
+
+function scoreColour(pct: number): string {
+  if (pct >= 90) return 'bg-green-500';
+  if (pct >= 70) return 'bg-blue-500';
+  if (pct >= 50) return 'bg-amber-500';
+  return 'bg-red-500';
+}
+
+function scoreTextColour(pct: number): string {
+  if (pct >= 90) return 'text-green-600';
+  if (pct >= 70) return 'text-blue-600';
+  if (pct >= 50) return 'text-amber-600';
+  return 'text-red-600';
+}
+
+export default function ProfilePage() {
+  const { isAuthenticated, isLoading: authLoading, loginWithRedirect, user } = useAuth0();
+  const { token, loading: tokenLoading } = useAccessToken();
+  const [stats, setStats] = useState<UserStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token) return;
+
+    async function loadStats() {
+      try {
+        const data = await getMyStats(token!);
+        setStats(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load stats');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadStats();
+  }, [token]);
+
+  if (authLoading || tokenLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <div className="text-center">
+          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600" />
+          <p className="mt-4 text-gray-600">Loading…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <div className="card max-w-md text-center">
+          <h2 className="text-xl font-bold text-gray-900 mb-2">Sign in to view your profile</h2>
+          <p className="text-gray-600 mb-4">Track your progress and see how you're improving.</p>
+          <button onClick={() => loginWithRedirect()} className="btn btn-primary">
+            Log In
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="card max-w-md mx-auto text-center">
+          <h2 className="text-xl font-bold text-red-600 mb-2">Error</h2>
+          <p className="text-gray-600">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const lawEntries = stats
+    ? (Object.entries(stats.byLaw) as [string, NonNullable<UserStats['byLaw'][keyof UserStats['byLaw']]>][]).sort(
+        (a, b) => a[0].localeCompare(b[0], undefined, { numeric: true })
+      )
+    : [];
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-3xl">
+      {/* Header */}
+      <div className="flex items-center gap-4 mb-8">
+        {user?.picture && (
+          <img src={user.picture} alt={user.name || 'User'} className="h-16 w-16 rounded-full" />
+        )}
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">{user?.name || user?.email}</h1>
+          <p className="text-gray-500 text-sm">{user?.email}</p>
+        </div>
+      </div>
+
+      {/* Summary stats */}
+      {stats && (
+        <>
+          <div className="grid grid-cols-3 gap-4 mb-8">
+            <div className="card text-center">
+              <div className="text-3xl font-bold text-gray-900">{stats.totalAttempts}</div>
+              <div className="text-sm text-gray-500 mt-1">Quizzes taken</div>
+            </div>
+            <div className="card text-center">
+              <div className={`text-3xl font-bold ${scoreTextColour(stats.averageScore)}`}>
+                {stats.averageScore.toFixed(1)}%
+              </div>
+              <div className="text-sm text-gray-500 mt-1">Average score</div>
+            </div>
+            <div className="card text-center">
+              <div className={`text-3xl font-bold ${scoreTextColour(stats.bestScore)}`}>
+                {stats.bestScore.toFixed(1)}%
+              </div>
+              <div className="text-sm text-gray-500 mt-1">Best score</div>
+            </div>
+          </div>
+
+          {/* Per-law breakdown */}
+          {lawEntries.length > 0 && (
+            <div className="card mb-6">
+              <h2 className="text-lg font-semibold text-gray-900 mb-4">Performance by Law</h2>
+              <div className="space-y-3">
+                {lawEntries.map(([law, lawStats]) => (
+                  <div key={law}>
+                    <div className="flex justify-between text-sm mb-1">
+                      <span className="font-medium text-gray-700">{law}</span>
+                      <span className={`font-semibold ${scoreTextColour(lawStats.avgScore)}`}>
+                        {lawStats.avgScore.toFixed(0)}%
+                        <span className="text-gray-400 font-normal ml-2">
+                          ({lawStats.attempts} attempt{lawStats.attempts !== 1 ? 's' : ''})
+                        </span>
+                      </span>
+                    </div>
+                    <div className="h-2 bg-gray-100 rounded-full overflow-hidden">
+                      <div
+                        className={`h-full rounded-full transition-all ${scoreColour(lawStats.avgScore)}`}
+                        style={{ width: `${Math.min(100, lawStats.avgScore)}%` }}
+                      />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {stats.totalAttempts === 0 && (
+            <div className="card text-center text-gray-500 mb-6">
+              <p className="mb-4">You haven't taken any quizzes yet.</p>
+              <Link to="/" className="btn btn-primary">
+                Browse Quizzes
+              </Link>
+            </div>
+          )}
+        </>
+      )}
+
+      <div className="flex gap-3">
+        <Link to="/history" className="btn btn-secondary">
+          View Full History
+        </Link>
+        <Link to="/" className="btn btn-primary">
+          Take a Quiz
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -239,3 +239,40 @@ export interface SubmitAnswersResponse {
     percentage: number;
   };
 }
+
+// User progress types (mirrors backend UserAttempt / UserStats)
+export interface PerQuestionResult {
+  questionId: string;
+  selectedOption: number;
+  isCorrect: boolean;
+  law: Law;
+}
+
+export interface LawStats {
+  attempts: number;
+  totalCorrect: number;
+  avgScore: number;
+  lastAttempt: string;
+}
+
+export interface UserAttempt {
+  attemptId: string;
+  quizId: string;
+  score: number;
+  total: number;
+  percentage: number;
+  questionResults: PerQuestionResult[];
+  createdAt: string;
+}
+
+export interface UserStats {
+  totalAttempts: number;
+  averageScore: number;
+  bestScore: number;
+  byLaw: Partial<Record<Law, LawStats>>;
+}
+
+export interface UserAttemptsResponse {
+  attempts: UserAttempt[];
+  nextCursor?: string;
+}


### PR DESCRIPTION
## Summary

Closes #12.

Adds `/profile` and `/history` routes for authenticated users, consuming the `GET /me/stats` and `GET /me/attempts` endpoints shipped in #69.

- **ProfilePage** (`/profile`): stat cards (quizzes taken, avg score, best score) + per-law progress bars with score-colour coding (≥90% green / ≥70% blue / ≥50% amber / <50% red)
- **HistoryPage** (`/history`): chronological attempt list with Load More cursor pagination
- **Navbar**: "My Progress" link visible to all authenticated users
- `api/client.ts`: `getMyAttempts` and `getMyStats` functions
- `types/index.ts`: `UserAttempt`, `UserStats`, `LawStats`, `UserAttemptsResponse`

Both pages show a login prompt for unauthenticated visitors and a spinner while loading.

## Test plan

- [ ] Log in and take a quiz; verify the attempt appears on `/history`
- [ ] Verify `/profile` shows correct totals and per-law bars
- [ ] Verify "My Progress" link appears in the navbar when logged in and is absent when logged out
- [ ] Verify Load More on `/history` appends the next page
- [ ] Verify unauthenticated visit to `/profile` and `/history` shows login prompt

https://claude.ai/code/session_01SGjm7Zfe2gR1fAqEdDwF8J

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGjm7Zfe2gR1fAqEdDwF8J)_