### PR TITLE
fix(infra): trigger terraform apply for /me Lambda endpoints

### DIFF
--- a/.infra/modules/backend/outputs.tf
+++ b/.infra/modules/backend/outputs.tf
@@ -1,5 +1,5 @@
 output "api_gateway_url" {
-  description = "API Gateway endpoint URL"
+  description = "API Gateway invoke URL for the deployed stage"
   value       = aws_api_gateway_stage.this.invoke_url
 }
 


### PR DESCRIPTION
## Summary

The `getMyAttempts` and `getMyStats` Lambda functions and their API Gateway routes (`/me/attempts`, `/me/stats`) were never deployed to AWS. Here's why:

1. PR #69 added the Terraform resources but `build.js` was missing the two new handlers, so `terraform plan` failed (couldn't read the ZIP files)
2. PR #70 fixed the build — but the CI ran through the **old** pipeline which had `environment: production` on the `terraform-apply` job (a manual approval gate)
3. PR #72 removed that gate, but it only changed `deploy.yml`, which doesn't trigger the `terraform` job

This PR makes a trivial change to `.infra/` to trigger the new consolidated `terraform` job (plan + apply, no approval gate) so the pending Lambda + API Gateway resources are finally created in AWS.

**This will fix the "Failed to fetch" error on the My Progress page.**

## Test plan

- [ ] CI `terraform` job runs plan then apply successfully
- [ ] `/me/stats` and `/me/attempts` endpoints respond (no more "Failed to fetch")
- [ ] My Progress page loads correctly after login

https://claude.ai/code/session_01SGjm7Zfe2gR1fAqEdDwF8J

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGjm7Zfe2gR1fAqEdDwF8J)_