### PR TITLE
feat(admin): add quiz deletion and platform analytics dashboard

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -168,6 +168,8 @@ jobs:
       lambda_authorize: ${{ steps.tf-output.outputs.lambda_authorize }}
       lambda_get_my_attempts: ${{ steps.tf-output.outputs.lambda_get_my_attempts }}
       lambda_get_my_stats: ${{ steps.tf-output.outputs.lambda_get_my_stats }}
+      lambda_delete_quiz: ${{ steps.tf-output.outputs.lambda_delete_quiz }}
+      lambda_get_admin_analytics: ${{ steps.tf-output.outputs.lambda_get_admin_analytics }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -209,6 +211,8 @@ jobs:
           echo "lambda_authorize=$(terraform output -json lambda_function_names | jq -r '.authorize')" >> $GITHUB_OUTPUT
           echo "lambda_get_my_attempts=$(terraform output -json lambda_function_names | jq -r '.get_my_attempts')" >> $GITHUB_OUTPUT
           echo "lambda_get_my_stats=$(terraform output -json lambda_function_names | jq -r '.get_my_stats')" >> $GITHUB_OUTPUT
+          echo "lambda_delete_quiz=$(terraform output -json lambda_function_names | jq -r '.delete_quiz')" >> $GITHUB_OUTPUT
+          echo "lambda_get_admin_analytics=$(terraform output -json lambda_function_names | jq -r '.get_admin_analytics')" >> $GITHUB_OUTPUT
 
   # Deploy Backend - uses pre-built artifacts
   deploy-backend:
@@ -345,6 +349,20 @@ jobs:
           aws lambda update-function-code \
             --function-name ${{ needs.get-outputs.outputs.lambda_get_my_stats }} \
             --zip-file fileb://backend/dist/getMyStats.zip
+
+      - name: Update Lambda - deleteQuiz
+        if: needs.get-outputs.outputs.lambda_delete_quiz != '' && needs.get-outputs.outputs.lambda_delete_quiz != 'null'
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ needs.get-outputs.outputs.lambda_delete_quiz }} \
+            --zip-file fileb://backend/dist/deleteQuiz.zip
+
+      - name: Update Lambda - getAdminAnalytics
+        if: needs.get-outputs.outputs.lambda_get_admin_analytics != '' && needs.get-outputs.outputs.lambda_get_admin_analytics != 'null'
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ needs.get-outputs.outputs.lambda_get_admin_analytics }} \
+            --zip-file fileb://backend/dist/getAdminAnalytics.zip
 
   # Build and Deploy Frontend
   deploy-frontend:

--- a/.infra/modules/backend/main.tf
+++ b/.infra/modules/backend/main.tf
@@ -22,6 +22,8 @@ locals {
     "authorize",
     "getMyAttempts",
     "getMyStats",
+    "deleteQuiz",
+    "getAdminAnalytics",
   ]
 }
 
@@ -437,6 +439,8 @@ resource "aws_api_gateway_deployment" "this" {
     aws_api_gateway_integration.remove_job_question,
     aws_api_gateway_integration.get_my_attempts,
     aws_api_gateway_integration.get_my_stats,
+    aws_api_gateway_integration.delete_quiz,
+    aws_api_gateway_integration.get_admin_analytics,
   ]
 
   lifecycle {
@@ -467,6 +471,7 @@ resource "aws_api_gateway_deployment" "this" {
       aws_api_gateway_resource.me.id,
       aws_api_gateway_resource.me_attempts.id,
       aws_api_gateway_resource.me_stats.id,
+      aws_api_gateway_resource.admin_analytics.id,
       [for r in aws_api_gateway_gateway_response.cors : r.id],
     ]))
   }
@@ -1617,6 +1622,122 @@ resource "aws_lambda_permission" "get_my_stats" {
   statement_id  = "AllowAPIGatewayInvoke"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.get_my_stats.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
+}
+
+# ============================================================================
+# Delete Quiz (DELETE /admin/jobs/{id})
+# ============================================================================
+
+resource "aws_lambda_function" "delete_quiz" {
+  filename         = "${path.module}/../../../backend/dist/deleteQuiz.zip"
+  function_name    = "${var.project_name}-${var.environment}-deleteQuiz"
+  role             = aws_iam_role.lambda_admin.arn
+  handler          = "index.handler"
+  runtime          = "nodejs24.x"
+  timeout          = 10
+  memory_size      = 256
+  source_code_hash = fileexists("${path.module}/../../../backend/dist/deleteQuiz.zip") ? filebase64sha256("${path.module}/../../../backend/dist/deleteQuiz.zip") : null
+
+  environment {
+    variables = {
+      TABLE_NAME = var.dynamodb_table_name
+      NODE_ENV   = var.environment
+    }
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-deleteQuiz"
+  }
+}
+
+resource "aws_api_gateway_method" "delete_quiz" {
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  resource_id   = aws_api_gateway_resource.admin_job_id.id
+  http_method   = "DELETE"
+  authorization = "CUSTOM"
+  authorizer_id = aws_api_gateway_authorizer.jwt.id
+}
+
+resource "aws_api_gateway_integration" "delete_quiz" {
+  rest_api_id             = aws_api_gateway_rest_api.this.id
+  resource_id             = aws_api_gateway_resource.admin_job_id.id
+  http_method             = aws_api_gateway_method.delete_quiz.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.delete_quiz.invoke_arn
+}
+
+resource "aws_lambda_permission" "delete_quiz" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.delete_quiz.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
+}
+
+# ============================================================================
+# Admin Analytics (GET /admin/analytics)
+# ============================================================================
+
+resource "aws_api_gateway_resource" "admin_analytics" {
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  parent_id   = aws_api_gateway_resource.admin.id
+  path_part   = "analytics"
+}
+
+resource "aws_lambda_function" "get_admin_analytics" {
+  filename         = "${path.module}/../../../backend/dist/getAdminAnalytics.zip"
+  function_name    = "${var.project_name}-${var.environment}-getAdminAnalytics"
+  role             = aws_iam_role.lambda_admin.arn
+  handler          = "index.handler"
+  runtime          = "nodejs24.x"
+  timeout          = 15
+  memory_size      = 256
+  source_code_hash = fileexists("${path.module}/../../../backend/dist/getAdminAnalytics.zip") ? filebase64sha256("${path.module}/../../../backend/dist/getAdminAnalytics.zip") : null
+
+  environment {
+    variables = {
+      TABLE_NAME = var.dynamodb_table_name
+      NODE_ENV   = var.environment
+    }
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-getAdminAnalytics"
+  }
+}
+
+resource "aws_api_gateway_method" "get_admin_analytics" {
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  resource_id   = aws_api_gateway_resource.admin_analytics.id
+  http_method   = "GET"
+  authorization = "CUSTOM"
+  authorizer_id = aws_api_gateway_authorizer.jwt.id
+}
+
+resource "aws_api_gateway_integration" "get_admin_analytics" {
+  rest_api_id             = aws_api_gateway_rest_api.this.id
+  resource_id             = aws_api_gateway_resource.admin_analytics.id
+  http_method             = aws_api_gateway_method.get_admin_analytics.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.get_admin_analytics.invoke_arn
+}
+
+module "cors_admin_analytics" {
+  source  = "squidfunk/api-gateway-enable-cors/aws"
+  version = "0.3.3"
+
+  api_id          = aws_api_gateway_rest_api.this.id
+  api_resource_id = aws_api_gateway_resource.admin_analytics.id
+}
+
+resource "aws_lambda_permission" "get_admin_analytics" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.get_admin_analytics.function_name
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
 }

--- a/.infra/modules/backend/outputs.tf
+++ b/.infra/modules/backend/outputs.tf
@@ -34,6 +34,8 @@ output "lambda_function_names" {
     authorize              = aws_lambda_function.authorize.function_name
     get_my_attempts        = aws_lambda_function.get_my_attempts.function_name
     get_my_stats           = aws_lambda_function.get_my_stats.function_name
+    delete_quiz            = aws_lambda_function.delete_quiz.function_name
+    get_admin_analytics    = aws_lambda_function.get_admin_analytics.function_name
   }
 }
 
@@ -58,6 +60,8 @@ output "lambda_function_arns" {
     authorize              = aws_lambda_function.authorize.arn
     get_my_attempts        = aws_lambda_function.get_my_attempts.arn
     get_my_stats           = aws_lambda_function.get_my_stats.arn
+    delete_quiz            = aws_lambda_function.delete_quiz.arn
+    get_admin_analytics    = aws_lambda_function.get_admin_analytics.arn
   }
 }
 

--- a/backend/build.js
+++ b/backend/build.js
@@ -34,6 +34,9 @@ const handlers = [
   // User progress
   'getMyAttempts',
   'getMyStats',
+  // Admin management
+  'deleteQuiz',
+  'getAdminAnalytics',
 ];
 
 async function buildHandler(handlerName) {

--- a/backend/src/handlers/deleteQuiz.ts
+++ b/backend/src/handlers/deleteQuiz.ts
@@ -1,0 +1,23 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from '../lib/types.js';
+import { getExtractionJob, deleteExtractionJob } from '../lib/dynamodb.js';
+import { successResponse, errorResponse } from '../lib/response.js';
+
+export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  const jobId = event.pathParameters?.id;
+  if (!jobId) {
+    return errorResponse('Missing quiz id', 400);
+  }
+
+  try {
+    const job = await getExtractionJob(jobId);
+    if (!job) {
+      return errorResponse('Quiz not found', 404);
+    }
+
+    await deleteExtractionJob(jobId);
+    return successResponse({ jobId, message: 'Quiz deleted successfully' });
+  } catch (error) {
+    console.error('Error deleting quiz:', error);
+    return errorResponse('Failed to delete quiz', 500);
+  }
+}

--- a/backend/src/handlers/getAdminAnalytics.ts
+++ b/backend/src/handlers/getAdminAnalytics.ts
@@ -1,0 +1,64 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult, Law, LawStats } from '../lib/types.js';
+import { getAllExtractionJobs, getAllUserStats } from '../lib/dynamodb.js';
+import { successResponse, errorResponse } from '../lib/response.js';
+
+export interface AdminAnalyticsResponse {
+  overview: {
+    totalUsers: number;
+    totalAttempts: number;
+    platformAvgScore: number;
+    publishedQuizzes: number;
+    totalQuestionsAvailable: number;
+  };
+  byLaw: Partial<Record<Law, { attempts: number; avgScore: number }>>;
+}
+
+export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  try {
+    const [jobs, userStats] = await Promise.all([getAllExtractionJobs(), getAllUserStats()]);
+
+    const publishedJobs = jobs.filter((j) => j.published === true);
+    const totalQuestionsAvailable = publishedJobs.reduce((sum, j) => sum + (j.approvedCount || 0), 0);
+
+    const usersWithAttempts = userStats.filter((u) => u.totalAttempts > 0);
+    const totalAttempts = userStats.reduce((sum, u) => sum + u.totalAttempts, 0);
+    const platformAvgScore =
+      usersWithAttempts.length > 0
+        ? usersWithAttempts.reduce((sum, u) => sum + u.averageScore, 0) / usersWithAttempts.length
+        : 0;
+
+    // Merge per-law stats across all users
+    const byLaw: Partial<Record<Law, { totalAttempts: number; totalCorrect: number }>> = {};
+    for (const user of userStats) {
+      for (const [law, stats] of Object.entries(user.byLaw || {}) as [Law, LawStats][]) {
+        if (!byLaw[law]) byLaw[law] = { totalAttempts: 0, totalCorrect: 0 };
+        byLaw[law]!.totalAttempts += stats.attempts;
+        byLaw[law]!.totalCorrect += stats.totalCorrect;
+      }
+    }
+
+    const byLawSummary: Partial<Record<Law, { attempts: number; avgScore: number }>> = {};
+    for (const [law, data] of Object.entries(byLaw) as [Law, { totalAttempts: number; totalCorrect: number }][]) {
+      byLawSummary[law] = {
+        attempts: data.totalAttempts,
+        avgScore: data.totalAttempts > 0 ? (data.totalCorrect / data.totalAttempts) * 100 : 0,
+      };
+    }
+
+    const response: AdminAnalyticsResponse = {
+      overview: {
+        totalUsers: userStats.length,
+        totalAttempts,
+        platformAvgScore: Math.round(platformAvgScore * 10) / 10,
+        publishedQuizzes: publishedJobs.length,
+        totalQuestionsAvailable,
+      },
+      byLaw: byLawSummary,
+    };
+
+    return successResponse(response);
+  } catch (error) {
+    console.error('Error fetching analytics:', error);
+    return errorResponse('Failed to fetch analytics', 500);
+  }
+}

--- a/backend/src/lib/dynamodb.ts
+++ b/backend/src/lib/dynamodb.ts
@@ -6,6 +6,7 @@ import {
   PutCommand,
   UpdateCommand,
   BatchWriteCommand,
+  DeleteCommand,
 } from '@aws-sdk/lib-dynamodb';
 import type {
   QuizItem,
@@ -496,6 +497,41 @@ export async function updateQuestionUsage(questionIds: string[]): Promise<void> 
       )
     )
   );
+}
+
+/**
+ * Delete an extraction job (quiz) by ID
+ */
+export async function deleteExtractionJob(jobId: string): Promise<void> {
+  await docClient.send(
+    new DeleteCommand({
+      TableName: TABLE_NAME,
+      Key: {
+        PK: `JOB#${jobId}`,
+        SK: 'METADATA',
+      },
+    })
+  );
+}
+
+/**
+ * Get all UserStats items for platform-wide analytics
+ */
+export async function getAllUserStats(): Promise<UserStatsItem[]> {
+  const params = {
+    TableName: TABLE_NAME,
+    IndexName: 'Type-createdAt-index',
+    KeyConditionExpression: '#type = :type',
+    ExpressionAttributeNames: {
+      '#type': 'Type',
+    },
+    ExpressionAttributeValues: {
+      ':type': 'UserStats',
+    },
+  };
+
+  const result = await docClient.send(new QueryCommand(params));
+  return (result.Items || []) as UserStatsItem[];
 }
 
 // ============================================================================

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -20,6 +20,7 @@ import type {
   UpdateQuizMetadataRequest,
   UserAttemptsResponse,
   UserStats,
+  AdminAnalytics,
 } from '../types';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
@@ -285,4 +286,15 @@ export async function removeQuizQuestion(
   token: string
 ): Promise<{ questionId: string; message: string; approvedCount: number }> {
   return fetchAPI(`/admin/jobs/${jobId}/questions/${questionId}`, { method: 'DELETE' }, token);
+}
+
+export async function deleteQuiz(
+  jobId: string,
+  token: string
+): Promise<{ jobId: string; message: string }> {
+  return fetchAPI(`/admin/jobs/${jobId}`, { method: 'DELETE' }, token);
+}
+
+export async function getAdminAnalytics(token: string): Promise<AdminAnalytics> {
+  return fetchAPI<AdminAnalytics>('/admin/analytics', undefined, token);
 }

--- a/frontend/src/pages/admin/Dashboard.tsx
+++ b/frontend/src/pages/admin/Dashboard.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { getExtractionJobs, getQuestionBank } from '../../api/client';
+import { getExtractionJobs, getQuestionBank, getAdminAnalytics } from '../../api/client';
 import { useAccessToken } from '../../hooks/useAccessToken';
-import type { ExtractionJob, BankQuestion } from '../../types';
+import type { ExtractionJob, BankQuestion, AdminAnalytics } from '../../types';
 
 interface Stats {
   totalQuestions: number;
@@ -18,6 +18,8 @@ export default function AdminDashboard() {
   const [recentJobs, setRecentJobs] = useState<ExtractionJob[]>([]);
   const [pendingQuestions, setPendingQuestions] = useState<BankQuestion[]>([]);
   const [loading, setLoading] = useState(true);
+  const [analytics, setAnalytics] = useState<AdminAnalytics | null>(null);
+  const [analyticsLoading, setAnalyticsLoading] = useState(true);
   const { getToken } = useAccessToken();
 
   useEffect(() => {
@@ -50,6 +52,21 @@ export default function AdminDashboard() {
     }
 
     loadData();
+  }, [getToken]);
+
+  useEffect(() => {
+    async function loadAnalytics() {
+      try {
+        const token = await getToken();
+        const data = await getAdminAnalytics(token);
+        setAnalytics(data);
+      } catch (error) {
+        console.error('Error loading analytics:', error);
+      } finally {
+        setAnalyticsLoading(false);
+      }
+    }
+    loadAnalytics();
   }, [getToken]);
 
   if (loading) {
@@ -182,6 +199,96 @@ export default function AdminDashboard() {
             Browse Question Bank
           </Link>
         </div>
+      </div>
+
+      {/* Learner Analytics */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-bold text-gray-900">Learner Analytics</h2>
+        {analyticsLoading ? (
+          <div className="flex items-center gap-2 text-gray-500">
+            <div className="inline-block animate-spin rounded-full h-5 w-5 border-b-2 border-primary-600"></div>
+            <span>Loading analytics...</span>
+          </div>
+        ) : analytics ? (
+          <>
+            <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+              <div className="bg-white rounded-lg shadow p-6">
+                <div className="text-sm font-medium text-gray-500">Total Learners</div>
+                <div className="mt-1 text-3xl font-bold text-gray-900">
+                  {analytics.overview.totalUsers}
+                </div>
+              </div>
+              <div className="bg-white rounded-lg shadow p-6">
+                <div className="text-sm font-medium text-gray-500">Total Attempts</div>
+                <div className="mt-1 text-3xl font-bold text-gray-900">
+                  {analytics.overview.totalAttempts}
+                </div>
+              </div>
+              <div className="bg-white rounded-lg shadow p-6">
+                <div className="text-sm font-medium text-gray-500">Platform Avg Score</div>
+                <div className="mt-1 text-3xl font-bold text-primary-600">
+                  {analytics.overview.platformAvgScore.toFixed(1)}%
+                </div>
+              </div>
+              <div className="bg-white rounded-lg shadow p-6">
+                <div className="text-sm font-medium text-gray-500">Published Quizzes</div>
+                <div className="mt-1 text-3xl font-bold text-gray-900">
+                  {analytics.overview.publishedQuizzes}
+                </div>
+              </div>
+              <div className="bg-white rounded-lg shadow p-6">
+                <div className="text-sm font-medium text-gray-500">Questions Available</div>
+                <div className="mt-1 text-3xl font-bold text-gray-900">
+                  {analytics.overview.totalQuestionsAvailable}
+                </div>
+              </div>
+            </div>
+
+            {Object.keys(analytics.byLaw).length > 0 && (
+              <div className="bg-white rounded-lg shadow p-6">
+                <h3 className="text-base font-semibold text-gray-900 mb-4">
+                  Performance by Law
+                </h3>
+                <div className="space-y-3">
+                  {(Object.entries(analytics.byLaw) as [string, { attempts: number; avgScore: number }][])
+                    .sort(([a], [b]) => {
+                      const num = (s: string) => parseInt(s.replace('Law ', ''), 10);
+                      return num(a) - num(b);
+                    })
+                    .map(([law, data]) => {
+                      const pct = Math.round(data.avgScore);
+                      const barColor =
+                        pct >= 90
+                          ? 'bg-green-500'
+                          : pct >= 70
+                            ? 'bg-blue-500'
+                            : pct >= 50
+                              ? 'bg-amber-500'
+                              : 'bg-red-500';
+                      return (
+                        <div key={law}>
+                          <div className="flex items-center justify-between text-sm mb-1">
+                            <span className="font-medium text-gray-700">{law}</span>
+                            <span className="text-gray-500">
+                              {pct}% avg · {data.attempts} attempts
+                            </span>
+                          </div>
+                          <div className="w-full bg-gray-100 rounded-full h-2">
+                            <div
+                              className={`${barColor} h-2 rounded-full transition-all`}
+                              style={{ width: `${pct}%` }}
+                            />
+                          </div>
+                        </div>
+                      );
+                    })}
+                </div>
+              </div>
+            )}
+          </>
+        ) : (
+          <p className="text-gray-500">Analytics unavailable.</p>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/admin/ManageQuizzes.tsx
+++ b/frontend/src/pages/admin/ManageQuizzes.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { getExtractionJobs, publishQuiz } from '../../api/client';
+import { getExtractionJobs, publishQuiz, deleteQuiz } from '../../api/client';
 import { useAccessToken } from '../../hooks/useAccessToken';
 import type { ExtractionJob } from '../../types';
 
@@ -16,6 +16,7 @@ export default function ManageQuizzes() {
   const [quizzes, setQuizzes] = useState<ExtractionJob[]>([]);
   const [loading, setLoading] = useState(true);
   const [toggling, setToggling] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState<string | null>(null);
 
   useEffect(() => {
     getToken()
@@ -37,6 +38,20 @@ export default function ManageQuizzes() {
       console.error('Toggle failed:', err);
     } finally {
       setToggling(null);
+    }
+  };
+
+  const handleDelete = async (quiz: ExtractionJob) => {
+    if (!window.confirm(`Delete "${formatTitle(quiz.fileName)}"? This cannot be undone.`)) return;
+    setDeleting(quiz.jobId);
+    try {
+      const token = await getToken();
+      await deleteQuiz(quiz.jobId, token);
+      setQuizzes((prev) => prev.filter((q) => q.jobId !== quiz.jobId));
+    } catch (err) {
+      console.error('Delete failed:', err);
+    } finally {
+      setDeleting(null);
     }
   };
 
@@ -163,6 +178,13 @@ export default function ManageQuizzes() {
                       >
                         ↗
                       </a>
+                      <button
+                        onClick={() => handleDelete(quiz)}
+                        disabled={deleting === quiz.jobId}
+                        className="text-sm text-red-600 hover:text-red-800 font-medium disabled:opacity-50"
+                      >
+                        Delete
+                      </button>
                     </div>
                   </td>
                 </tr>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -276,3 +276,17 @@ export interface UserAttemptsResponse {
   attempts: UserAttempt[];
   nextCursor?: string;
 }
+
+// Admin analytics types
+export interface AdminAnalyticsOverview {
+  totalUsers: number;
+  totalAttempts: number;
+  platformAvgScore: number;
+  publishedQuizzes: number;
+  totalQuestionsAvailable: number;
+}
+
+export interface AdminAnalytics {
+  overview: AdminAnalyticsOverview;
+  byLaw: Partial<Record<Law, { attempts: number; avgScore: number }>>;
+}


### PR DESCRIPTION
## Summary

- Implements #54 — admins can now delete quizzes via `DELETE /admin/jobs/:id`, with a confirmation dialog and optimistic removal from the UI
- Implements #52 — new `GET /admin/analytics` endpoint aggregates all user stats and published quiz data; Admin Dashboard shows a "Learner Analytics" section with 5 platform-wide stat cards and colour-coded per-law performance bars

## What changed

- **Backend**: `deleteExtractionJob` + `getAllUserStats` added to `dynamodb.ts`; two new Lambda handlers (`deleteQuiz`, `getAdminAnalytics`)
- **Infrastructure**: Terraform resources for both Lambdas, API Gateway methods/integrations, CORS, Lambda permissions; outputs and deploy pipeline updated
- **Frontend**: `AdminAnalytics` type, `deleteQuiz` + `getAdminAnalytics` API functions; Delete button in ManageQuizzes; Learner Analytics section in Dashboard

## How to test

- Admin → Manage Quizzes → click Delete on a quiz → confirm → quiz disappears from list
- Admin → Dashboard → scroll to "Learner Analytics" → stat cards and per-law bars render (loads independently, won't block the page)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SGjm7Zfe2gR1fAqEdDwF8J)_