### PR TITLE
feat(practice): smart practice mode with weakness targeting

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -170,6 +170,7 @@ jobs:
       lambda_get_my_stats: ${{ steps.tf-output.outputs.lambda_get_my_stats }}
       lambda_delete_quiz: ${{ steps.tf-output.outputs.lambda_delete_quiz }}
       lambda_get_admin_analytics: ${{ steps.tf-output.outputs.lambda_get_admin_analytics }}
+      lambda_get_practice_quiz: ${{ steps.tf-output.outputs.lambda_get_practice_quiz }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -213,6 +214,7 @@ jobs:
           echo "lambda_get_my_stats=$(terraform output -json lambda_function_names | jq -r '.get_my_stats')" >> $GITHUB_OUTPUT
           echo "lambda_delete_quiz=$(terraform output -json lambda_function_names | jq -r '.delete_quiz')" >> $GITHUB_OUTPUT
           echo "lambda_get_admin_analytics=$(terraform output -json lambda_function_names | jq -r '.get_admin_analytics')" >> $GITHUB_OUTPUT
+          echo "lambda_get_practice_quiz=$(terraform output -json lambda_function_names | jq -r '.get_practice_quiz')" >> $GITHUB_OUTPUT
 
   # Deploy Backend - uses pre-built artifacts
   deploy-backend:
@@ -363,6 +365,13 @@ jobs:
           aws lambda update-function-code \
             --function-name ${{ needs.get-outputs.outputs.lambda_get_admin_analytics }} \
             --zip-file fileb://backend/dist/getAdminAnalytics.zip
+
+      - name: Update Lambda - getPracticeQuiz
+        if: needs.get-outputs.outputs.lambda_get_practice_quiz != '' && needs.get-outputs.outputs.lambda_get_practice_quiz != 'null'
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ needs.get-outputs.outputs.lambda_get_practice_quiz }} \
+            --zip-file fileb://backend/dist/getPracticeQuiz.zip
 
   # Build and Deploy Frontend
   deploy-frontend:

--- a/.infra/modules/backend/main.tf
+++ b/.infra/modules/backend/main.tf
@@ -24,6 +24,7 @@ locals {
     "getMyStats",
     "deleteQuiz",
     "getAdminAnalytics",
+    "getPracticeQuiz",
   ]
 }
 
@@ -441,6 +442,7 @@ resource "aws_api_gateway_deployment" "this" {
     aws_api_gateway_integration.get_my_stats,
     aws_api_gateway_integration.delete_quiz,
     aws_api_gateway_integration.get_admin_analytics,
+    aws_api_gateway_integration.get_practice_quiz,
   ]
 
   lifecycle {
@@ -471,6 +473,7 @@ resource "aws_api_gateway_deployment" "this" {
       aws_api_gateway_resource.me.id,
       aws_api_gateway_resource.me_attempts.id,
       aws_api_gateway_resource.me_stats.id,
+      aws_api_gateway_resource.me_practice.id,
       aws_api_gateway_resource.admin_analytics.id,
       [for r in aws_api_gateway_gateway_response.cors : r.id],
     ]))
@@ -1622,6 +1625,71 @@ resource "aws_lambda_permission" "get_my_stats" {
   statement_id  = "AllowAPIGatewayInvoke"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.get_my_stats.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
+}
+
+# ============================================================================
+# Practice Quiz (GET /me/practice-quiz)
+# ============================================================================
+
+resource "aws_lambda_function" "get_practice_quiz" {
+  filename         = "${path.module}/../../../backend/dist/getPracticeQuiz.zip"
+  function_name    = "${var.project_name}-${var.environment}-getPracticeQuiz"
+  role             = aws_iam_role.lambda.arn
+  handler          = "index.handler"
+  runtime          = "nodejs24.x"
+  timeout          = 15
+  memory_size      = 256
+  source_code_hash = fileexists("${path.module}/../../../backend/dist/getPracticeQuiz.zip") ? filebase64sha256("${path.module}/../../../backend/dist/getPracticeQuiz.zip") : null
+
+  environment {
+    variables = {
+      TABLE_NAME   = var.dynamodb_table_name
+      AUTH0_DOMAIN = var.auth0_domain
+      NODE_ENV     = var.environment
+    }
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-getPracticeQuiz"
+  }
+}
+
+resource "aws_api_gateway_resource" "me_practice" {
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  parent_id   = aws_api_gateway_resource.me.id
+  path_part   = "practice-quiz"
+}
+
+resource "aws_api_gateway_method" "get_practice_quiz" {
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  resource_id   = aws_api_gateway_resource.me_practice.id
+  http_method   = "GET"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "get_practice_quiz" {
+  rest_api_id             = aws_api_gateway_rest_api.this.id
+  resource_id             = aws_api_gateway_resource.me_practice.id
+  http_method             = aws_api_gateway_method.get_practice_quiz.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.get_practice_quiz.invoke_arn
+}
+
+module "cors_me_practice" {
+  source  = "squidfunk/api-gateway-enable-cors/aws"
+  version = "0.3.3"
+
+  api_id          = aws_api_gateway_rest_api.this.id
+  api_resource_id = aws_api_gateway_resource.me_practice.id
+}
+
+resource "aws_lambda_permission" "get_practice_quiz" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.get_practice_quiz.function_name
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
 }

--- a/.infra/modules/backend/outputs.tf
+++ b/.infra/modules/backend/outputs.tf
@@ -36,6 +36,7 @@ output "lambda_function_names" {
     get_my_stats           = aws_lambda_function.get_my_stats.function_name
     delete_quiz            = aws_lambda_function.delete_quiz.function_name
     get_admin_analytics    = aws_lambda_function.get_admin_analytics.function_name
+    get_practice_quiz      = aws_lambda_function.get_practice_quiz.function_name
   }
 }
 
@@ -62,6 +63,7 @@ output "lambda_function_arns" {
     get_my_stats           = aws_lambda_function.get_my_stats.arn
     delete_quiz            = aws_lambda_function.delete_quiz.arn
     get_admin_analytics    = aws_lambda_function.get_admin_analytics.arn
+    get_practice_quiz      = aws_lambda_function.get_practice_quiz.arn
   }
 }
 

--- a/backend/build.js
+++ b/backend/build.js
@@ -37,6 +37,8 @@ const handlers = [
   // Admin management
   'deleteQuiz',
   'getAdminAnalytics',
+  // Practice mode
+  'getPracticeQuiz',
 ];
 
 async function buildHandler(handlerName) {

--- a/backend/src/handlers/getPracticeQuiz.ts
+++ b/backend/src/handlers/getPracticeQuiz.ts
@@ -1,0 +1,90 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from '../lib/types.js';
+import type { Law, BankQuestionItem } from '../lib/types.js';
+import { getUserStats, getQuestionsByLaw, shuffleArray } from '../lib/dynamodb.js';
+import { successResponse, errorResponse } from '../lib/response.js';
+import { verifyToken } from '../lib/verifyToken.js';
+
+const ALL_LAWS: Law[] = [
+  'Law 1', 'Law 2', 'Law 3', 'Law 4', 'Law 5', 'Law 6', 'Law 7', 'Law 8', 'Law 9',
+  'Law 10', 'Law 11', 'Law 12', 'Law 13', 'Law 14', 'Law 15', 'Law 16', 'Law 17',
+];
+
+export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  const userId = await verifyToken(
+    event.headers?.Authorization || event.headers?.authorization
+  );
+  if (!userId) return errorResponse('Authentication required', 401);
+
+  const limit = Math.min(
+    parseInt(event.queryStringParameters?.limit || '20', 10),
+    40
+  );
+
+  try {
+    const stats = await getUserStats(userId);
+    const byLaw = stats?.byLaw || {};
+
+    // Weight each law: weaker laws get more questions (range 10–100)
+    const weights: Partial<Record<Law, number>> = {};
+    for (const law of ALL_LAWS) {
+      const lawStats = byLaw[law];
+      if (lawStats && lawStats.attempts > 0) {
+        weights[law] = Math.max(10, 100 - lawStats.avgScore);
+      } else {
+        weights[law] = 50;
+      }
+    }
+
+    const totalWeight = ALL_LAWS.reduce((s, l) => s + (weights[l] ?? 0), 0);
+
+    // Allocate question budget per law, proportional to weight
+    const lawBudgets: Partial<Record<Law, number>> = {};
+    let allocated = 0;
+    for (const law of ALL_LAWS) {
+      const budget = Math.round(((weights[law] ?? 0) / totalWeight) * limit);
+      lawBudgets[law] = budget;
+      allocated += budget;
+    }
+    // Distribute rounding remainder to the weakest law
+    const remainder = limit - allocated;
+    if (remainder !== 0) {
+      const weakest = ALL_LAWS.reduce((a, b) =>
+        (weights[a] ?? 0) >= (weights[b] ?? 0) ? a : b
+      );
+      lawBudgets[weakest] = (lawBudgets[weakest] ?? 0) + remainder;
+    }
+
+    // Fetch and sample questions per law in parallel
+    const selected: BankQuestionItem[] = [];
+    await Promise.all(
+      ALL_LAWS.map(async (law) => {
+        const budget = lawBudgets[law] ?? 0;
+        if (budget === 0) return;
+        const questions = await getQuestionsByLaw(law, 'approved', 100);
+        shuffleArray(questions).slice(0, budget).forEach((q) => selected.push(q));
+      })
+    );
+
+    const shuffled = shuffleArray(selected);
+
+    // Top 3 focus laws (lowest avgScore with existing data)
+    const focusLaws = ALL_LAWS
+      .filter((l) => byLaw[l]?.attempts)
+      .sort((a, b) => (byLaw[a]?.avgScore ?? 100) - (byLaw[b]?.avgScore ?? 100))
+      .slice(0, 3);
+
+    const questions = shuffled.map((q) => ({
+      questionId: q.questionId,
+      text: q.text,
+      options: q.options,
+      correctAnswer: q.correctAnswer,
+      explanation: q.explanation,
+      lawReference: q.lawReference,
+    }));
+
+    return successResponse({ questions, focusLaws });
+  } catch (error) {
+    console.error('Error generating practice quiz:', error);
+    return errorResponse('Failed to generate practice quiz', 500);
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import AdminEditQuiz from './pages/admin/EditQuiz';
 import AdminQuizQuestions from './pages/admin/QuizQuestions';
 import ProfilePage from './pages/ProfilePage';
 import HistoryPage from './pages/HistoryPage';
+import PracticeTake from './pages/PracticeTake';
 
 export default function App() {
   return (
@@ -29,6 +30,7 @@ export default function App() {
         <Route path="/quiz/:quizId/results" element={<QuizResults />} />
         <Route path="/profile" element={<ProfilePage />} />
         <Route path="/history" element={<HistoryPage />} />
+        <Route path="/practice" element={<PracticeTake />} />
       </Route>
 
       {/* Protected admin routes */}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -21,6 +21,7 @@ import type {
   UserAttemptsResponse,
   UserStats,
   AdminAnalytics,
+  PracticeQuizResponse,
 } from '../types';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
@@ -297,4 +298,18 @@ export async function deleteQuiz(
 
 export async function getAdminAnalytics(token: string): Promise<AdminAnalytics> {
   return fetchAPI<AdminAnalytics>('/admin/analytics', undefined, token);
+}
+
+export async function getPracticeQuiz(
+  token: string,
+  limit?: number
+): Promise<PracticeQuizResponse> {
+  const params = new URLSearchParams();
+  if (limit !== undefined) params.set('limit', limit.toString());
+  const query = params.toString();
+  return fetchAPI<PracticeQuizResponse>(
+    `/me/practice-quiz${query ? `?${query}` : ''}`,
+    undefined,
+    token
+  );
 }

--- a/frontend/src/pages/PracticeTake.tsx
+++ b/frontend/src/pages/PracticeTake.tsx
@@ -1,0 +1,377 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth0 } from '@auth0/auth0-react';
+import { getPracticeQuiz } from '../api/client';
+import type { StudyQuestion, Answer, Law } from '../types';
+
+const OPTION_LABELS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+function shuffleArray<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+function buildShuffleMap(questions: StudyQuestion[]): Record<string, number[]> {
+  const map: Record<string, number[]> = {};
+  for (const q of questions) {
+    map[q.questionId] = shuffleArray(q.options.map((_, i) => i));
+  }
+  return map;
+}
+
+type Phase = 'loading' | 'preview' | 'quiz' | 'results' | 'error';
+
+interface QuestionResult {
+  question: StudyQuestion;
+  selectedOption: number;
+  isCorrect: boolean;
+}
+
+export default function PracticeTake() {
+  const navigate = useNavigate();
+  const { getIdTokenClaims } = useAuth0();
+
+  const [phase, setPhase] = useState<Phase>('loading');
+  const [questions, setQuestions] = useState<StudyQuestion[]>([]);
+  const [focusLaws, setFocusLaws] = useState<Law[]>([]);
+  const [shuffleMap, setShuffleMap] = useState<Record<string, number[]>>({});
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [answers, setAnswers] = useState<Answer[]>([]);
+  const [feedbackRevealed, setFeedbackRevealed] = useState(false);
+  const [results, setResults] = useState<QuestionResult[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const answersRef = useRef<Answer[]>([]);
+  useEffect(() => { answersRef.current = answers; }, [answers]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const claims = await getIdTokenClaims();
+        const token = claims?.__raw;
+        if (!token) {
+          setError('Authentication required');
+          setPhase('error');
+          return;
+        }
+        const data = await getPracticeQuiz(token, 20);
+        if (data.questions.length === 0) {
+          setError('No approved questions available yet. Check back after an admin publishes a quiz.');
+          setPhase('error');
+          return;
+        }
+        setQuestions(data.questions);
+        setFocusLaws(data.focusLaws);
+        setShuffleMap(buildShuffleMap(data.questions));
+        setPhase('preview');
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load practice questions');
+        setPhase('error');
+      }
+    }
+    load();
+  }, [getIdTokenClaims]);
+
+  const currentQuestion = questions[currentIndex];
+  const currentAnswer = answers.find((a) => a.questionId === currentQuestion?.questionId);
+  const hasAnswered = currentAnswer !== undefined && currentAnswer.selectedOption >= 0;
+  const isLast = currentIndex === questions.length - 1;
+
+  const currentShuffledOptions = useMemo(() => {
+    if (!currentQuestion) return [];
+    const order = shuffleMap[currentQuestion.questionId];
+    return order ? order.map((i) => currentQuestion.options[i]) : currentQuestion.options;
+  }, [currentQuestion, shuffleMap]);
+
+  const handleSelectOption = useCallback(
+    (displayIndex: number) => {
+      if (!currentQuestion || feedbackRevealed) return;
+      const order = shuffleMap[currentQuestion.questionId];
+      const originalIndex = order ? order[displayIndex] : displayIndex;
+      setAnswers((prev) => {
+        const existing = prev.find((a) => a.questionId === currentQuestion.questionId);
+        if (existing) {
+          return prev.map((a) =>
+            a.questionId === currentQuestion.questionId
+              ? { ...a, selectedOption: originalIndex }
+              : a
+          );
+        }
+        return [...prev, { questionId: currentQuestion.questionId, selectedOption: originalIndex }];
+      });
+    },
+    [currentQuestion, shuffleMap, feedbackRevealed]
+  );
+
+  const handleCheck = useCallback(() => setFeedbackRevealed(true), []);
+
+  const handleNext = useCallback(() => {
+    setFeedbackRevealed(false);
+    setCurrentIndex((i) => i + 1);
+  }, []);
+
+  const handleFinish = useCallback(() => {
+    const finalResults: QuestionResult[] = questions.map((q) => {
+      const ans = answersRef.current.find((a) => a.questionId === q.questionId);
+      const selected = ans?.selectedOption ?? -1;
+      return { question: q, selectedOption: selected, isCorrect: selected === q.correctAnswer };
+    });
+    setResults(finalResults);
+    setPhase('results');
+  }, [questions]);
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    if (phase !== 'quiz' || !currentQuestion) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (target?.isContentEditable || target?.tagName === 'INPUT') return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      if (e.key >= 'a' && e.key <= 'z') {
+        const idx = e.key.charCodeAt(0) - 97;
+        if (idx < currentQuestion.options.length) { e.preventDefault(); handleSelectOption(idx); }
+        return;
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        if (hasAnswered && !feedbackRevealed) handleCheck();
+        else if (feedbackRevealed) isLast ? handleFinish() : handleNext();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [phase, currentQuestion, hasAnswered, feedbackRevealed, isLast, handleSelectOption, handleCheck, handleNext, handleFinish]);
+
+  if (phase === 'loading') {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600" />
+          <p className="mt-4 text-gray-600">Building your practice session...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === 'error') {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="card max-w-md text-center">
+          <p className="text-gray-600 mb-4">{error}</p>
+          <button onClick={() => navigate('/')} className="btn-secondary">Back to Quizzes</button>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === 'preview') {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="card max-w-lg text-center">
+          <div className="text-4xl mb-4">🎯</div>
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">Practice Mode</h2>
+          <p className="text-gray-600 mb-6">
+            {questions.length} questions selected based on your performance. Get instant feedback
+            after each answer.
+          </p>
+          {focusLaws.length > 0 && (
+            <div className="mb-6 p-4 bg-amber-50 border border-amber-200 rounded-lg text-left">
+              <p className="text-sm font-semibold text-amber-800 mb-2">Focus areas this session:</p>
+              <div className="flex flex-wrap gap-2">
+                {focusLaws.map((law) => (
+                  <span
+                    key={law}
+                    className="px-2 py-1 bg-amber-100 text-amber-800 text-xs font-medium rounded-full"
+                  >
+                    {law}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+          <button onClick={() => setPhase('quiz')} className="btn-primary w-full">
+            Start Practice →
+          </button>
+          <button onClick={() => navigate('/')} className="mt-3 text-sm text-gray-500 hover:text-gray-700">
+            ← Back to Quizzes
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === 'results') {
+    const correct = results.filter((r) => r.isCorrect).length;
+    const pct = Math.round((correct / results.length) * 100);
+    return (
+      <div className="container mx-auto px-4 py-8 max-w-3xl">
+        <div className="card text-center mb-8">
+          <div className="text-5xl font-bold text-primary-600 mb-2">{pct}%</div>
+          <p className="text-gray-600 mb-1">
+            {correct} of {results.length} correct
+          </p>
+          <p className="text-sm text-gray-400">Practice complete</p>
+          <div className="mt-6 flex gap-3 justify-center">
+            <button onClick={() => navigate('/practice')} className="btn-primary">
+              Practice Again
+            </button>
+            <button onClick={() => navigate('/')} className="btn-secondary">
+              Back to Quizzes
+            </button>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          {results.map((r, idx) => (
+            <div
+              key={r.question.questionId}
+              className={`card border-l-4 ${r.isCorrect ? 'border-green-500' : 'border-red-500'}`}
+            >
+              <p className="text-sm font-medium text-gray-500 mb-1">
+                Q{idx + 1} · {r.isCorrect ? '✓ Correct' : '✗ Incorrect'} · {r.question.lawReference}
+              </p>
+              <p className="text-gray-900 mb-3">{r.question.text}</p>
+              {!r.isCorrect && (
+                <p className="text-sm text-gray-600 mb-2">
+                  <span className="font-medium">Correct answer:</span>{' '}
+                  {r.question.options[r.question.correctAnswer]}
+                </p>
+              )}
+              <p className="text-sm text-blue-700 bg-blue-50 p-3 rounded">{r.question.explanation}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // Quiz phase
+  if (!currentQuestion) return null;
+
+  const progress = ((currentIndex + 1) / questions.length) * 100;
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-3xl">
+      <div className="mb-6">
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-3">
+            <h1 className="text-xl font-bold text-gray-900">Practice Mode</h1>
+            <span className="px-2 py-0.5 text-xs font-medium bg-amber-100 text-amber-800 rounded-full">
+              Study
+            </span>
+          </div>
+          <span className="text-sm text-gray-600">
+            Question {currentIndex + 1} of {questions.length}
+          </span>
+        </div>
+        <div className="w-full bg-gray-200 rounded-full h-2">
+          <div
+            className="bg-primary-600 h-2 rounded-full transition-all duration-300"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      </div>
+
+      <div className="card mb-6">
+        <h2 className="text-xl font-semibold text-gray-900 mb-6">{currentQuestion.text}</h2>
+
+        <div className="space-y-3">
+          {currentShuffledOptions.map((option, displayIndex) => {
+            const originalIndex = shuffleMap[currentQuestion.questionId]?.[displayIndex] ?? displayIndex;
+            const isSelected = currentAnswer?.selectedOption === originalIndex;
+            const showFeedback = feedbackRevealed;
+            const isCorrect = showFeedback && originalIndex === currentQuestion.correctAnswer;
+            const isWrong = showFeedback && isSelected && !isCorrect;
+
+            let borderClass = 'border-gray-200 hover:border-gray-300 bg-white';
+            if (isCorrect) borderClass = 'border-green-500 bg-green-50';
+            else if (isWrong) borderClass = 'border-red-500 bg-red-50';
+            else if (isSelected) borderClass = 'border-primary-600 bg-primary-50';
+
+            return (
+              <button
+                key={displayIndex}
+                onClick={() => handleSelectOption(displayIndex)}
+                disabled={feedbackRevealed}
+                className={`w-full text-left p-4 rounded-lg border-2 transition-all disabled:cursor-default ${borderClass}`}
+              >
+                <div className="flex items-center">
+                  <div
+                    className={`flex-shrink-0 w-6 h-6 rounded-full border-2 mr-3 flex items-center justify-center ${
+                      isCorrect
+                        ? 'border-green-600 bg-green-600'
+                        : isWrong
+                          ? 'border-red-600 bg-red-600'
+                          : isSelected
+                            ? 'border-primary-600 bg-primary-600'
+                            : 'border-gray-300'
+                    }`}
+                  >
+                    {(isSelected || isCorrect) && (
+                      <svg className="w-4 h-4 text-white" fill="currentColor" viewBox="0 0 20 20">
+                        {isWrong ? (
+                          <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+                        ) : (
+                          <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                        )}
+                      </svg>
+                    )}
+                  </div>
+                  <span className="inline-flex items-center justify-center w-6 h-6 mr-3 text-xs font-mono font-semibold text-gray-500 bg-gray-100 rounded">
+                    {OPTION_LABELS[displayIndex]}
+                  </span>
+                  <span className="text-gray-900">{option}</span>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        {feedbackRevealed && (
+          <div className="mt-6 bg-blue-50 border-l-4 border-blue-500 p-4 rounded">
+            <p className="text-sm font-semibold text-blue-900 mb-1">
+              {currentAnswer?.selectedOption === currentQuestion.correctAnswer ? '✓ Correct!' : '✗ Incorrect'}{' '}
+              — {currentQuestion.lawReference}
+            </p>
+            <p className="text-sm text-blue-800">{currentQuestion.explanation}</p>
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div />
+        {hasAnswered && !feedbackRevealed ? (
+          <button onClick={handleCheck} className="px-6 py-2 rounded-lg font-medium bg-green-600 text-white hover:bg-green-700">
+            Check Answer
+          </button>
+        ) : feedbackRevealed && isLast ? (
+          <button onClick={handleFinish} className="btn-primary">
+            See Results
+          </button>
+        ) : feedbackRevealed ? (
+          <button onClick={handleNext} className="btn-primary">
+            Continue →
+          </button>
+        ) : (
+          <div />
+        )}
+      </div>
+
+      <p className="hidden sm:block text-center text-xs text-gray-400 mt-6">
+        Shortcuts:{' '}
+        <kbd className="px-1.5 py-0.5 bg-gray-100 border border-gray-200 rounded">A</kbd>–
+        <kbd className="px-1.5 py-0.5 bg-gray-100 border border-gray-200 rounded">
+          {OPTION_LABELS[currentQuestion.options.length - 1]}
+        </kbd>{' '}
+        select ·{' '}
+        <kbd className="px-1.5 py-0.5 bg-gray-100 border border-gray-200 rounded">Enter</kbd>{' '}
+        {hasAnswered && !feedbackRevealed ? 'check' : feedbackRevealed ? (isLast ? 'results' : 'next') : ''}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/QuizList.tsx
+++ b/frontend/src/pages/QuizList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
 import { getQuizzes } from '../api/client';
 import Hero from '../components/Hero';
@@ -10,6 +10,7 @@ const ALL_CATEGORIES = '__all__';
 
 export default function QuizList() {
   const { isAuthenticated } = useAuth0();
+  const navigate = useNavigate();
   const [quizzes, setQuizzes] = useState<QuizSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -76,6 +77,25 @@ export default function QuizList() {
         id="quizzes"
         className="container mx-auto px-4 py-12 max-w-4xl scroll-mt-16"
       >
+        {isAuthenticated && (
+          <ScrollReveal>
+            <div className="mb-8 p-5 bg-gradient-to-r from-amber-50 to-orange-50 border border-amber-200 rounded-xl flex items-center justify-between gap-4">
+              <div>
+                <h3 className="font-semibold text-gray-900">Practice Mode</h3>
+                <p className="text-sm text-gray-600">
+                  Targeted questions based on your weak areas — with instant feedback.
+                </p>
+              </div>
+              <button
+                onClick={() => navigate('/practice')}
+                className="flex-shrink-0 px-4 py-2 rounded-lg font-medium bg-amber-500 text-white hover:bg-amber-600 transition-colors"
+              >
+                Start Practice
+              </button>
+            </div>
+          </ScrollReveal>
+        )}
+
         <ScrollReveal>
           <header className="mb-6">
             <h2 className="text-2xl font-bold text-gray-900">Available Quizzes</h2>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -277,6 +277,12 @@ export interface UserAttemptsResponse {
   nextCursor?: string;
 }
 
+// Practice mode types
+export interface PracticeQuizResponse {
+  questions: StudyQuestion[];
+  focusLaws: Law[];
+}
+
 // Admin analytics types
 export interface AdminAnalyticsOverview {
   totalUsers: number;


### PR DESCRIPTION
## Summary

Implements #53 — authenticated users can now launch a personalised practice session from the home page.

- Questions are sampled from the approved question bank weighted toward laws where the user scores lowest (or uniformly if no history yet)
- Each question shows instant feedback with explanation (study mode throughout)
- Focus laws shown on the preview screen before starting
- Full results review at the end

## What changed

- **Backend**: `GET /me/practice-quiz` Lambda — fetches user stats, computes law weights, samples up to 20 approved questions proportionally, returns them with correct answers + explanations
- **Infrastructure**: new Lambda, `/me/practice-quiz` API Gateway resource, CORS module, Lambda permission; added to deployment triggers and CI outputs
- **Frontend**: `PracticeTake` page with preview → quiz → results flow; `PracticeQuizResponse` type; `getPracticeQuiz` API function; Practice Mode banner on QuizList for authenticated users

## How to test

1. Log in as a user
2. Home page shows an amber "Practice Mode" banner → click "Start Practice"
3. Preview screen shows your focus laws (or none if no history yet)
4. Answer questions — each shows correct/incorrect immediately with explanation
5. Results screen shows score + full question review


---
_Generated by [Claude Code](https://claude.ai/code/session_01SGjm7Zfe2gR1fAqEdDwF8J)_