### PR TITLE
feat(admin): edit existing questions (text, options, correctAnswer, etc.)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -161,6 +161,7 @@ jobs:
       lambda_get_question_bank: ${{ steps.tf-output.outputs.lambda_get_question_bank }}
       lambda_review_question: ${{ steps.tf-output.outputs.lambda_review_question }}
       lambda_bulk_review_questions: ${{ steps.tf-output.outputs.lambda_bulk_review_questions }}
+      lambda_update_question: ${{ steps.tf-output.outputs.lambda_update_question }}
       lambda_get_extraction_jobs: ${{ steps.tf-output.outputs.lambda_get_extraction_jobs }}
       lambda_publish_quiz: ${{ steps.tf-output.outputs.lambda_publish_quiz }}
       lambda_create_manual_job: ${{ steps.tf-output.outputs.lambda_create_manual_job }}
@@ -205,6 +206,7 @@ jobs:
           echo "lambda_get_question_bank=$(terraform output -json lambda_function_names | jq -r '.get_question_bank')" >> $GITHUB_OUTPUT
           echo "lambda_review_question=$(terraform output -json lambda_function_names | jq -r '.review_question')" >> $GITHUB_OUTPUT
           echo "lambda_bulk_review_questions=$(terraform output -json lambda_function_names | jq -r '.bulk_review_questions')" >> $GITHUB_OUTPUT
+          echo "lambda_update_question=$(terraform output -json lambda_function_names | jq -r '.update_question')" >> $GITHUB_OUTPUT
           echo "lambda_get_extraction_jobs=$(terraform output -json lambda_function_names | jq -r '.get_extraction_jobs')" >> $GITHUB_OUTPUT
           echo "lambda_publish_quiz=$(terraform output -json lambda_function_names | jq -r '.publish_quiz')" >> $GITHUB_OUTPUT
           echo "lambda_create_manual_job=$(terraform output -json lambda_function_names | jq -r '.create_manual_job')" >> $GITHUB_OUTPUT
@@ -295,6 +297,13 @@ jobs:
           aws lambda update-function-code \
             --function-name ${{ needs.get-outputs.outputs.lambda_review_question }} \
             --zip-file fileb://backend/dist/reviewQuestion.zip
+
+      - name: Update Lambda - updateQuestion
+        if: needs.get-outputs.outputs.lambda_update_question != '' && needs.get-outputs.outputs.lambda_update_question != 'null'
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ needs.get-outputs.outputs.lambda_update_question }} \
+            --zip-file fileb://backend/dist/updateQuestion.zip
 
       - name: Update Lambda - bulkReviewQuestions
         if: needs.get-outputs.outputs.lambda_bulk_review_questions != '' && needs.get-outputs.outputs.lambda_bulk_review_questions != 'null'

--- a/.infra/modules/backend/main.tf
+++ b/.infra/modules/backend/main.tf
@@ -13,6 +13,7 @@ locals {
     "getQuestionBank",
     "reviewQuestion",
     "bulkReviewQuestions",
+    "updateQuestion",
     "publishQuiz",
     "getExtractionJobs",
     "createManualJob",
@@ -433,6 +434,7 @@ resource "aws_api_gateway_deployment" "this" {
     aws_api_gateway_integration.get_job,
     aws_api_gateway_integration.get_question_bank,
     aws_api_gateway_integration.review_question,
+    aws_api_gateway_integration.update_question,
     aws_api_gateway_integration.bulk_review,
     aws_api_gateway_integration.publish_quiz,
     aws_api_gateway_integration.create_manual_job,
@@ -848,6 +850,32 @@ resource "aws_lambda_function" "bulk_review_questions" {
 }
 
 # ============================================================================
+# Lambda Function: updateQuestion
+# ============================================================================
+
+resource "aws_lambda_function" "update_question" {
+  filename         = "${path.module}/../../../backend/dist/updateQuestion.zip"
+  function_name    = "${var.project_name}-${var.environment}-updateQuestion"
+  role             = aws_iam_role.lambda_admin.arn
+  handler          = "index.handler"
+  runtime          = "nodejs24.x"
+  timeout          = 10
+  memory_size      = 256
+  source_code_hash = fileexists("${path.module}/../../../backend/dist/updateQuestion.zip") ? filebase64sha256("${path.module}/../../../backend/dist/updateQuestion.zip") : null
+
+  environment {
+    variables = {
+      TABLE_NAME = var.dynamodb_table_name
+      NODE_ENV   = var.environment
+    }
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-updateQuestion"
+  }
+}
+
+# ============================================================================
 # Lambda Function: publishQuiz
 # ============================================================================
 
@@ -1074,6 +1102,26 @@ resource "aws_api_gateway_integration" "review_question" {
   uri                     = aws_lambda_function.review_question.invoke_arn
 }
 
+# PUT /admin/questions/{id} - edit question content (text, options,
+# correctAnswer, explanation, law, lawReference). Distinct from /review
+# which only changes approval status.
+resource "aws_api_gateway_method" "update_question" {
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  resource_id   = aws_api_gateway_resource.admin_question_id.id
+  http_method   = "PUT"
+  authorization = "CUSTOM"
+  authorizer_id = aws_api_gateway_authorizer.jwt.id
+}
+
+resource "aws_api_gateway_integration" "update_question" {
+  rest_api_id             = aws_api_gateway_rest_api.this.id
+  resource_id             = aws_api_gateway_resource.admin_question_id.id
+  http_method             = aws_api_gateway_method.update_question.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.update_question.invoke_arn
+}
+
 # /admin/questions/bulk-review
 resource "aws_api_gateway_resource" "admin_bulk_review" {
   rest_api_id = aws_api_gateway_rest_api.this.id
@@ -1154,6 +1202,14 @@ module "cors_admin_question_review" {
 
   api_id          = aws_api_gateway_rest_api.this.id
   api_resource_id = aws_api_gateway_resource.admin_question_review.id
+}
+
+module "cors_admin_question_id" {
+  source  = "squidfunk/api-gateway-enable-cors/aws"
+  version = "0.3.3"
+
+  api_id          = aws_api_gateway_rest_api.this.id
+  api_resource_id = aws_api_gateway_resource.admin_question_id.id
 }
 
 module "cors_admin_bulk_review" {
@@ -1457,6 +1513,14 @@ resource "aws_lambda_permission" "review_question" {
   statement_id  = "AllowAPIGatewayInvoke"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.review_question.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
+}
+
+resource "aws_lambda_permission" "update_question" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.update_question.function_name
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
 }

--- a/.infra/modules/backend/outputs.tf
+++ b/.infra/modules/backend/outputs.tf
@@ -25,6 +25,7 @@ output "lambda_function_names" {
     get_question_bank      = aws_lambda_function.get_question_bank.function_name
     review_question        = aws_lambda_function.review_question.function_name
     bulk_review_questions  = aws_lambda_function.bulk_review_questions.function_name
+    update_question        = aws_lambda_function.update_question.function_name
     get_extraction_jobs    = aws_lambda_function.get_extraction_jobs.function_name
     publish_quiz           = aws_lambda_function.publish_quiz.function_name
     create_manual_job      = aws_lambda_function.create_manual_job.function_name
@@ -51,6 +52,7 @@ output "lambda_function_arns" {
     process_pdf            = aws_lambda_function.process_pdf.arn
     get_question_bank      = aws_lambda_function.get_question_bank.arn
     review_question        = aws_lambda_function.review_question.arn
+    update_question        = aws_lambda_function.update_question.arn
     bulk_review_questions  = aws_lambda_function.bulk_review_questions.arn
     get_extraction_jobs    = aws_lambda_function.get_extraction_jobs.arn
     publish_quiz           = aws_lambda_function.publish_quiz.arn

--- a/backend/build.js
+++ b/backend/build.js
@@ -21,6 +21,7 @@ const handlers = [
   'getQuestionBank',
   'reviewQuestion',
   'bulkReviewQuestions',
+  'updateQuestion',
   'getExtractionJobs',
   'publishQuiz',
   // Manual quiz creation handlers

--- a/backend/src/handlers/updateQuestion.ts
+++ b/backend/src/handlers/updateQuestion.ts
@@ -1,0 +1,132 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult, Law } from '../lib/types.js';
+import { getBankQuestion, updateBankQuestionContent } from '../lib/dynamodb.js';
+import { successResponse, errorResponse } from '../lib/response.js';
+
+interface UpdateQuestionRequest {
+  text?: string;
+  options?: string[];
+  correctAnswer?: number;
+  explanation?: string;
+  law?: Law;
+  lawReference?: string;
+}
+
+const VALID_LAWS = new Set<Law>([
+  'Law 1', 'Law 2', 'Law 3', 'Law 4', 'Law 5', 'Law 6', 'Law 7', 'Law 8', 'Law 9',
+  'Law 10', 'Law 11', 'Law 12', 'Law 13', 'Law 14', 'Law 15', 'Law 16', 'Law 17',
+]);
+
+/**
+ * PUT /admin/questions/{id}
+ * Update the editable content of a bank question. Used to fix AI-extraction
+ * errors (e.g. a wrong correctAnswer) or polish the wording of options.
+ *
+ * Only the fields present in the request body are updated. Status changes
+ * still go through /admin/questions/{id}/review.
+ */
+export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  console.log('Event:', JSON.stringify(event, null, 2));
+
+  const questionId = event.pathParameters?.id;
+  if (!questionId) {
+    return errorResponse('Missing question ID', 400);
+  }
+
+  if (!event.body) {
+    return errorResponse('Request body is required', 400);
+  }
+
+  let request: UpdateQuestionRequest;
+  try {
+    request = JSON.parse(event.body);
+  } catch {
+    return errorResponse('Invalid JSON body', 400);
+  }
+
+  const updates: UpdateQuestionRequest = {};
+
+  if (request.text !== undefined) {
+    if (typeof request.text !== 'string' || request.text.trim() === '') {
+      return errorResponse('text must be a non-empty string', 400);
+    }
+    updates.text = request.text.trim();
+  }
+
+  if (request.options !== undefined) {
+    if (
+      !Array.isArray(request.options) ||
+      request.options.length < 2 ||
+      request.options.length > 8 ||
+      request.options.some((o) => typeof o !== 'string' || o.trim() === '')
+    ) {
+      return errorResponse('options must be an array of 2-8 non-empty strings', 400);
+    }
+    updates.options = request.options.map((o) => o.trim());
+  }
+
+  if (request.correctAnswer !== undefined) {
+    if (
+      typeof request.correctAnswer !== 'number' ||
+      !Number.isInteger(request.correctAnswer) ||
+      request.correctAnswer < 0
+    ) {
+      return errorResponse('correctAnswer must be a non-negative integer', 400);
+    }
+    updates.correctAnswer = request.correctAnswer;
+  }
+
+  if (request.explanation !== undefined) {
+    if (typeof request.explanation !== 'string') {
+      return errorResponse('explanation must be a string', 400);
+    }
+    updates.explanation = request.explanation.trim();
+  }
+
+  if (request.law !== undefined) {
+    if (!VALID_LAWS.has(request.law)) {
+      return errorResponse('law must be one of Law 1 through Law 17', 400);
+    }
+    updates.law = request.law;
+  }
+
+  if (request.lawReference !== undefined) {
+    if (typeof request.lawReference !== 'string' || request.lawReference.trim() === '') {
+      return errorResponse('lawReference must be a non-empty string', 400);
+    }
+    updates.lawReference = request.lawReference.trim();
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return errorResponse('At least one field must be provided', 400);
+  }
+
+  try {
+    const existing = await getBankQuestion(questionId);
+    if (!existing) {
+      return errorResponse('Question not found', 404);
+    }
+
+    // Cross-field validation: correctAnswer must index into options. Check
+    // against the new options if they're being changed, otherwise the
+    // existing options.
+    const effectiveOptions = updates.options ?? existing.options;
+    const effectiveCorrect = updates.correctAnswer ?? existing.correctAnswer;
+    if (effectiveCorrect >= effectiveOptions.length) {
+      return errorResponse(
+        `correctAnswer ${effectiveCorrect} is out of range for ${effectiveOptions.length} option(s)`,
+        400
+      );
+    }
+
+    await updateBankQuestionContent(questionId, updates);
+
+    return successResponse({
+      questionId,
+      updated: Object.keys(updates),
+      message: 'Question updated successfully',
+    });
+  } catch (error) {
+    console.error('Error updating question:', error);
+    return errorResponse('Failed to update question', 500);
+  }
+}

--- a/backend/src/lib/dynamodb.ts
+++ b/backend/src/lib/dynamodb.ts
@@ -261,6 +261,46 @@ export async function updateBankQuestionStatus(
 }
 
 /**
+ * Update the editable content of a bank question (text, options,
+ * correctAnswer, explanation, law, lawReference). Only the fields
+ * present in `updates` are written; everything else is left untouched.
+ */
+export async function updateBankQuestionContent(
+  questionId: string,
+  updates: Partial<
+    Pick<BankQuestionItem, 'text' | 'options' | 'correctAnswer' | 'explanation' | 'law' | 'lawReference'>
+  >
+): Promise<void> {
+  const setExpressions: string[] = ['updatedAt = :updatedAt'];
+  const attributeNames: Record<string, string> = {};
+  const attributeValues: Record<string, unknown> = {
+    ':updatedAt': new Date().toISOString(),
+  };
+
+  for (const [key, value] of Object.entries(updates)) {
+    if (value === undefined) continue;
+    setExpressions.push(`#${key} = :${key}`);
+    attributeNames[`#${key}`] = key;
+    attributeValues[`:${key}`] = value;
+  }
+
+  if (setExpressions.length === 1) {
+    // Nothing besides updatedAt to write - skip the round trip.
+    return;
+  }
+
+  await docClient.send(
+    new UpdateCommand({
+      TableName: TABLE_NAME,
+      Key: { PK: `QUESTION#${questionId}`, SK: 'METADATA' },
+      UpdateExpression: `SET ${setExpressions.join(', ')}`,
+      ExpressionAttributeNames: attributeNames,
+      ExpressionAttributeValues: attributeValues,
+    })
+  );
+}
+
+/**
  * Get questions by status (for review queue)
  */
 export async function getQuestionsByStatus(

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -17,6 +17,8 @@ import type {
   AddManualQuestionRequest,
   AddManualQuestionResponse,
   SubmitAnswersResponse,
+  UpdateQuestionRequest,
+  UpdateQuestionResponse,
   UpdateQuizMetadataRequest,
   UserAttemptsResponse,
   UserStats,
@@ -279,6 +281,18 @@ export async function getMyAttempts(
 
 export async function getMyStats(token: string): Promise<UserStats> {
   return fetchAPI<UserStats>('/me/stats', undefined, token);
+}
+
+export async function updateQuestion(
+  questionId: string,
+  updates: UpdateQuestionRequest,
+  token: string
+): Promise<UpdateQuestionResponse> {
+  return fetchAPI<UpdateQuestionResponse>(
+    `/admin/questions/${questionId}`,
+    { method: 'PUT', body: JSON.stringify(updates) },
+    token
+  );
 }
 
 export async function removeQuizQuestion(

--- a/frontend/src/components/admin/QuestionEditor.tsx
+++ b/frontend/src/components/admin/QuestionEditor.tsx
@@ -1,0 +1,224 @@
+import { useState } from 'react';
+import { updateQuestion } from '../../api/client';
+import { useAccessToken } from '../../hooks/useAccessToken';
+import type { BankQuestion, Law } from '../../types';
+
+const LAWS: Law[] = [
+  'Law 1', 'Law 2', 'Law 3', 'Law 4', 'Law 5', 'Law 6', 'Law 7', 'Law 8', 'Law 9',
+  'Law 10', 'Law 11', 'Law 12', 'Law 13', 'Law 14', 'Law 15', 'Law 16', 'Law 17',
+];
+
+interface QuestionEditorProps {
+  question: BankQuestion;
+  onSaved: (updated: BankQuestion) => void;
+  onCancel: () => void;
+}
+
+export default function QuestionEditor({ question, onSaved, onCancel }: QuestionEditorProps) {
+  const { getToken } = useAccessToken();
+  const [text, setText] = useState(question.text);
+  const [options, setOptions] = useState<string[]>(() => [...question.options]);
+  const [correctAnswer, setCorrectAnswer] = useState(question.correctAnswer);
+  const [explanation, setExplanation] = useState(question.explanation ?? '');
+  const [law, setLaw] = useState<Law>(question.law);
+  const [lawReference, setLawReference] = useState(question.lawReference ?? '');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const setOption = (index: number, value: string) => {
+    setOptions((prev) => prev.map((o, i) => (i === index ? value : o)));
+  };
+
+  const addOption = () => {
+    if (options.length >= 8) return;
+    setOptions((prev) => [...prev, '']);
+  };
+
+  const removeOption = (index: number) => {
+    if (options.length <= 2) return;
+    setOptions((prev) => prev.filter((_, i) => i !== index));
+    // Keep correctAnswer pointing at the same option after removal.
+    if (correctAnswer === index) {
+      setCorrectAnswer(0);
+    } else if (correctAnswer > index) {
+      setCorrectAnswer(correctAnswer - 1);
+    }
+  };
+
+  const handleSave = async () => {
+    setError(null);
+
+    if (!text.trim()) {
+      setError('Question text is required');
+      return;
+    }
+    if (options.some((o) => !o.trim())) {
+      setError('All options must be filled in');
+      return;
+    }
+    if (correctAnswer < 0 || correctAnswer >= options.length) {
+      setError('Pick which option is correct');
+      return;
+    }
+    if (!lawReference.trim()) {
+      setError('Law reference is required');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const token = await getToken();
+      await updateQuestion(
+        question.questionId,
+        {
+          text: text.trim(),
+          options: options.map((o) => o.trim()),
+          correctAnswer,
+          explanation: explanation.trim(),
+          law,
+          lawReference: lawReference.trim(),
+        },
+        token
+      );
+      onSaved({
+        ...question,
+        text: text.trim(),
+        options: options.map((o) => o.trim()),
+        correctAnswer,
+        explanation: explanation.trim(),
+        law,
+        lawReference: lawReference.trim(),
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-amber-900">Editing question</h3>
+        <span className="text-xs font-mono text-amber-700">{question.questionId}</span>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded p-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <div>
+        <label className="block text-xs font-medium text-gray-700 mb-1">Question text</label>
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          rows={2}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+        />
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between mb-1">
+          <label className="block text-xs font-medium text-gray-700">
+            Options (pick the radio next to the correct answer)
+          </label>
+          <button
+            type="button"
+            onClick={addOption}
+            disabled={options.length >= 8}
+            className="text-xs text-primary-700 hover:underline disabled:opacity-40 disabled:no-underline"
+          >
+            + Add option
+          </button>
+        </div>
+        <div className="space-y-2">
+          {options.map((opt, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name={`correct-${question.questionId}`}
+                  checked={correctAnswer === i}
+                  onChange={() => setCorrectAnswer(i)}
+                  className="w-4 h-4 text-primary-600"
+                />
+                <span className="text-xs font-mono text-gray-500 w-4">
+                  {String.fromCharCode(65 + i)}
+                </span>
+              </label>
+              <input
+                type="text"
+                value={opt}
+                onChange={(e) => setOption(i, e.target.value)}
+                className="flex-1 px-3 py-1.5 border border-gray-300 rounded text-sm focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              />
+              <button
+                type="button"
+                onClick={() => removeOption(i)}
+                disabled={options.length <= 2}
+                className="text-xs text-red-600 hover:text-red-800 disabled:opacity-40 disabled:cursor-not-allowed px-2"
+                aria-label="Remove option"
+              >
+                ✕
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <div className="sm:col-span-1">
+          <label className="block text-xs font-medium text-gray-700 mb-1">Law</label>
+          <select
+            value={law}
+            onChange={(e) => setLaw(e.target.value as Law)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white focus:ring-2 focus:ring-primary-500"
+          >
+            {LAWS.map((l) => (
+              <option key={l} value={l}>
+                {l}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="sm:col-span-2">
+          <label className="block text-xs font-medium text-gray-700 mb-1">
+            Law reference (e.g. Law 12.4)
+          </label>
+          <input
+            type="text"
+            value={lawReference}
+            onChange={(e) => setLawReference(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-xs font-medium text-gray-700 mb-1">Explanation</label>
+        <textarea
+          value={explanation}
+          onChange={(e) => setExplanation(e.target.value)}
+          rows={3}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+        />
+      </div>
+
+      <div className="flex items-center justify-end gap-2 pt-2 border-t border-amber-200">
+        <button type="button" onClick={onCancel} className="btn-secondary text-sm">
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving}
+          className="btn-primary text-sm disabled:opacity-50"
+        >
+          {saving ? 'Saving…' : 'Save changes'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/QuizQuestions.tsx
+++ b/frontend/src/pages/admin/QuizQuestions.tsx
@@ -7,6 +7,7 @@ import {
   removeQuizQuestion,
 } from '../../api/client';
 import { useAccessToken } from '../../hooks/useAccessToken';
+import QuestionEditor from '../../components/admin/QuestionEditor';
 import type { JobDetailResponse, BankQuestion, Law } from '../../types';
 
 const LAWS: Law[] = [
@@ -44,6 +45,7 @@ export default function QuizQuestions() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [removing, setRemoving] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
 
   // Question picker state
   const [showPicker, setShowPicker] = useState(false);
@@ -284,36 +286,67 @@ export default function QuizQuestions() {
           ) : (
             approvedQuestions.map((q, idx) => (
               <div key={q.questionId} className="px-6 py-4">
-                <div className="flex items-start justify-between gap-4">
-                  <div className="flex-1">
-                    <div className="flex items-center gap-2 mb-2">
-                      <span className="text-sm font-medium text-gray-400">{idx + 1}.</span>
-                      <span className="text-xs font-medium px-2 py-0.5 bg-blue-100 text-blue-800 rounded">
-                        {q.law}
-                      </span>
+                {editingId === q.questionId ? (
+                  <QuestionEditor
+                    question={q}
+                    onSaved={(updated) => {
+                      setJob((prev) =>
+                        prev
+                          ? {
+                              ...prev,
+                              questions: prev.questions.map((it) =>
+                                it.questionId === updated.questionId ? updated : it
+                              ),
+                            }
+                          : prev
+                      );
+                      setEditingId(null);
+                    }}
+                    onCancel={() => setEditingId(null)}
+                  />
+                ) : (
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex-1">
+                      <div className="flex items-center gap-2 mb-2">
+                        <span className="text-sm font-medium text-gray-400">{idx + 1}.</span>
+                        <span className="text-xs font-medium px-2 py-0.5 bg-blue-100 text-blue-800 rounded">
+                          {q.law}
+                        </span>
+                        {q.lawReference && q.lawReference !== q.law && (
+                          <span className="text-xs font-mono text-gray-400">{q.lawReference}</span>
+                        )}
+                      </div>
+                      <p className="text-gray-900 mb-2">{q.text}</p>
+                      <div className="grid gap-1">
+                        {q.options.map((opt, i) => (
+                          <div
+                            key={i}
+                            className={`px-3 py-1.5 rounded text-sm ${i === q.correctAnswer ? 'bg-green-50 border border-green-200 text-green-800' : 'bg-gray-50 text-gray-700'}`}
+                          >
+                            <span className="font-medium mr-2">{String.fromCharCode(65 + i)}.</span>
+                            {opt}
+                            {i === q.correctAnswer && <span className="ml-2 text-green-600">✓</span>}
+                          </div>
+                        ))}
+                      </div>
                     </div>
-                    <p className="text-gray-900 mb-2">{q.text}</p>
-                    <div className="grid gap-1">
-                      {q.options.map((opt, i) => (
-                        <div
-                          key={i}
-                          className={`px-3 py-1.5 rounded text-sm ${i === q.correctAnswer ? 'bg-green-50 border border-green-200 text-green-800' : 'bg-gray-50 text-gray-700'}`}
-                        >
-                          <span className="font-medium mr-2">{String.fromCharCode(65 + i)}.</span>
-                          {opt}
-                          {i === q.correctAnswer && <span className="ml-2 text-green-600">✓</span>}
-                        </div>
-                      ))}
+                    <div className="flex flex-col gap-2 flex-shrink-0">
+                      <button
+                        onClick={() => setEditingId(q.questionId)}
+                        className="px-3 py-1 text-sm font-medium text-primary-700 bg-primary-50 rounded hover:bg-primary-100"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => handleRemove(q.questionId)}
+                        disabled={removing === q.questionId}
+                        className="px-3 py-1 text-sm font-medium text-red-700 bg-red-100 rounded hover:bg-red-200 disabled:opacity-50"
+                      >
+                        {removing === q.questionId ? '...' : 'Remove'}
+                      </button>
                     </div>
                   </div>
-                  <button
-                    onClick={() => handleRemove(q.questionId)}
-                    disabled={removing === q.questionId}
-                    className="px-3 py-1 text-sm font-medium text-red-700 bg-red-100 rounded hover:bg-red-200 disabled:opacity-50 flex-shrink-0"
-                  >
-                    {removing === q.questionId ? '...' : 'Remove'}
-                  </button>
-                </div>
+                )}
               </div>
             ))
           )}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -204,6 +204,21 @@ export interface AddManualQuestionResponse {
   message: string;
 }
 
+export interface UpdateQuestionRequest {
+  text?: string;
+  options?: string[];
+  correctAnswer?: number;
+  explanation?: string;
+  law?: Law;
+  lawReference?: string;
+}
+
+export interface UpdateQuestionResponse {
+  questionId: string;
+  updated: string[];
+  message: string;
+}
+
 export interface UpdateQuizMetadataRequest {
   title?: string;
   description?: string;


### PR DESCRIPTION
## Why

There was no way to fix a question once it was approved. If the AI extraction picked the wrong option as the answer, or the wording was slightly off, the only options were to remove the question entirely or re-import the whole PDF. This adds a proper edit path.

(Prompted by the DOGSO question on the Elite Referees LOTG Quiz 1 — whether the AI's pick was right is a fair interpretive call given how the IFAB advantage text is worded for the "goal scored" case, but the broader inability to edit a question's answer is the real fix here.)

## What

**Backend**
- `PUT /admin/questions/{id}` — handler `updateQuestion.ts`. Validates each editable field (text, options array of 2-8 non-empty strings, `correctAnswer` non-negative integer in range of the resulting options, explanation string, law in the 17-law enum, lawReference non-empty). Only fields present in the request body are written. Cross-field check rejects a `correctAnswer` that lands outside the new options array.
- `updateBankQuestionContent` in `dynamodb.ts` builds a partial `UpdateExpression` so only changed fields are written.
- Terraform: Lambda + method + integration + CORS module + Lambda permission, added to the deployment trigger. Function name flows through `outputs.tf`, the workflow's `get-outputs` job, and a new `Update Lambda - updateQuestion` step in `deploy-backend` — so future authorize-style fixes ship without an infra apply.

**Frontend**
- New `QuestionEditor` component: textarea for the question, editable list of options with a radio for which is correct (per-option add/remove, 2-8 range), law dropdown, law-reference input, explanation textarea. Save calls the new endpoint and patches the local list; cancel reverts.
- `QuizQuestions` page gets an Edit button per question that toggles between the read-only view and the editor.

## Test plan

- [ ] As admin, open `/admin/quizzes/{jobId}/questions` for any approved quiz
- [ ] Click "Edit" on a question — inline form appears with current values prefilled
- [ ] Change the correct-answer radio, click Save — list refreshes, the green ✓ moves to the new option, no page reload
- [ ] Edit option text — saves and re-renders
- [ ] Add an option (up to 8), remove an option (down to 2)
- [ ] Set `correctAnswer` to the last option then remove that option — UI keeps `correctAnswer` consistent (resets to 0 or shifts down)
- [ ] Empty out the question text and click Save — inline error shows, no API call
- [ ] CloudWatch: `lotg-exams-prod-updateQuestion` shows the request body and "updated" array

## Follow-ups (not in this PR)

- Unit tests for `updateQuestion` (validation matrix). Backend tests all still pass; happy to add in a follow-up if you want.
- Bulk-edit (e.g. set all questions for a Law to a new lawReference format) — would be a separate handler.

https://claude.ai/code/session_012ovSD71NbDWLfcCwfsdtE2

---
_Generated by [Claude Code](https://claude.ai/code/session_012ovSD71NbDWLfcCwfsdtE2)_