### PR TITLE
feat: mock exam, streaks, exam readiness, bookmarks, law viewer, PWA, CSV import

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -171,6 +171,9 @@ jobs:
       lambda_delete_quiz: ${{ steps.tf-output.outputs.lambda_delete_quiz }}
       lambda_get_admin_analytics: ${{ steps.tf-output.outputs.lambda_get_admin_analytics }}
       lambda_get_practice_quiz: ${{ steps.tf-output.outputs.lambda_get_practice_quiz }}
+      lambda_get_bookmarks: ${{ steps.tf-output.outputs.lambda_get_bookmarks }}
+      lambda_add_bookmark: ${{ steps.tf-output.outputs.lambda_add_bookmark }}
+      lambda_remove_bookmark: ${{ steps.tf-output.outputs.lambda_remove_bookmark }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -215,6 +218,9 @@ jobs:
           echo "lambda_delete_quiz=$(terraform output -json lambda_function_names | jq -r '.delete_quiz')" >> $GITHUB_OUTPUT
           echo "lambda_get_admin_analytics=$(terraform output -json lambda_function_names | jq -r '.get_admin_analytics')" >> $GITHUB_OUTPUT
           echo "lambda_get_practice_quiz=$(terraform output -json lambda_function_names | jq -r '.get_practice_quiz')" >> $GITHUB_OUTPUT
+          echo "lambda_get_bookmarks=$(terraform output -json lambda_function_names | jq -r '.get_bookmarks')" >> $GITHUB_OUTPUT
+          echo "lambda_add_bookmark=$(terraform output -json lambda_function_names | jq -r '.add_bookmark')" >> $GITHUB_OUTPUT
+          echo "lambda_remove_bookmark=$(terraform output -json lambda_function_names | jq -r '.remove_bookmark')" >> $GITHUB_OUTPUT
 
   # Deploy Backend - uses pre-built artifacts
   deploy-backend:
@@ -372,6 +378,27 @@ jobs:
           aws lambda update-function-code \
             --function-name ${{ needs.get-outputs.outputs.lambda_get_practice_quiz }} \
             --zip-file fileb://backend/dist/getPracticeQuiz.zip
+
+      - name: Update Lambda - getBookmarks
+        if: needs.get-outputs.outputs.lambda_get_bookmarks != '' && needs.get-outputs.outputs.lambda_get_bookmarks != 'null'
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ needs.get-outputs.outputs.lambda_get_bookmarks }} \
+            --zip-file fileb://backend/dist/getBookmarks.zip
+
+      - name: Update Lambda - addBookmark
+        if: needs.get-outputs.outputs.lambda_add_bookmark != '' && needs.get-outputs.outputs.lambda_add_bookmark != 'null'
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ needs.get-outputs.outputs.lambda_add_bookmark }} \
+            --zip-file fileb://backend/dist/addBookmark.zip
+
+      - name: Update Lambda - removeBookmark
+        if: needs.get-outputs.outputs.lambda_remove_bookmark != '' && needs.get-outputs.outputs.lambda_remove_bookmark != 'null'
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ needs.get-outputs.outputs.lambda_remove_bookmark }} \
+            --zip-file fileb://backend/dist/removeBookmark.zip
 
   # Build and Deploy Frontend
   deploy-frontend:

--- a/.infra/modules/backend/main.tf
+++ b/.infra/modules/backend/main.tf
@@ -26,6 +26,9 @@ locals {
     "getAdminAnalytics",
     "getPracticeQuiz",
     "importQuestionsCSV",
+    "addBookmark",
+    "removeBookmark",
+    "getBookmarks",
   ]
 }
 
@@ -445,6 +448,9 @@ resource "aws_api_gateway_deployment" "this" {
     aws_api_gateway_integration.get_admin_analytics,
     aws_api_gateway_integration.get_practice_quiz,
     aws_api_gateway_integration.import_questions_csv,
+    aws_api_gateway_integration.get_bookmarks,
+    aws_api_gateway_integration.add_bookmark,
+    aws_api_gateway_integration.remove_bookmark,
   ]
 
   lifecycle {
@@ -478,6 +484,8 @@ resource "aws_api_gateway_deployment" "this" {
       aws_api_gateway_resource.me_practice.id,
       aws_api_gateway_resource.admin_analytics.id,
       aws_api_gateway_resource.admin_questions_import.id,
+      aws_api_gateway_resource.me_bookmarks.id,
+      aws_api_gateway_resource.me_bookmark_id.id,
       [for r in aws_api_gateway_gateway_response.cors : r.id],
     ]))
   }
@@ -1880,3 +1888,181 @@ resource "aws_lambda_permission" "import_questions_csv" {
   source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
 }
 
+# ============================================================================
+# Bookmarks (GET/POST /me/bookmarks, DELETE /me/bookmarks/{questionId})
+# ============================================================================
+
+resource "aws_api_gateway_resource" "me_bookmarks" {
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  parent_id   = aws_api_gateway_resource.me.id
+  path_part   = "bookmarks"
+}
+
+resource "aws_api_gateway_resource" "me_bookmark_id" {
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  parent_id   = aws_api_gateway_resource.me_bookmarks.id
+  path_part   = "{questionId}"
+}
+
+# Lambda: getBookmarks
+resource "aws_lambda_function" "get_bookmarks" {
+  filename         = "${path.module}/../../../backend/dist/getBookmarks.zip"
+  function_name    = "${var.project_name}-${var.environment}-getBookmarks"
+  role             = aws_iam_role.lambda.arn
+  handler          = "index.handler"
+  runtime          = "nodejs24.x"
+  timeout          = 10
+  memory_size      = 256
+  source_code_hash = fileexists("${path.module}/../../../backend/dist/getBookmarks.zip") ? filebase64sha256("${path.module}/../../../backend/dist/getBookmarks.zip") : null
+
+  environment {
+    variables = {
+      TABLE_NAME   = var.dynamodb_table_name
+      AUTH0_DOMAIN = var.auth0_domain
+      NODE_ENV     = var.environment
+    }
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-getBookmarks"
+  }
+}
+
+# Lambda: addBookmark
+resource "aws_lambda_function" "add_bookmark" {
+  filename         = "${path.module}/../../../backend/dist/addBookmark.zip"
+  function_name    = "${var.project_name}-${var.environment}-addBookmark"
+  role             = aws_iam_role.lambda.arn
+  handler          = "index.handler"
+  runtime          = "nodejs24.x"
+  timeout          = 10
+  memory_size      = 256
+  source_code_hash = fileexists("${path.module}/../../../backend/dist/addBookmark.zip") ? filebase64sha256("${path.module}/../../../backend/dist/addBookmark.zip") : null
+
+  environment {
+    variables = {
+      TABLE_NAME   = var.dynamodb_table_name
+      AUTH0_DOMAIN = var.auth0_domain
+      NODE_ENV     = var.environment
+    }
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-addBookmark"
+  }
+}
+
+# Lambda: removeBookmark
+resource "aws_lambda_function" "remove_bookmark" {
+  filename         = "${path.module}/../../../backend/dist/removeBookmark.zip"
+  function_name    = "${var.project_name}-${var.environment}-removeBookmark"
+  role             = aws_iam_role.lambda.arn
+  handler          = "index.handler"
+  runtime          = "nodejs24.x"
+  timeout          = 10
+  memory_size      = 256
+  source_code_hash = fileexists("${path.module}/../../../backend/dist/removeBookmark.zip") ? filebase64sha256("${path.module}/../../../backend/dist/removeBookmark.zip") : null
+
+  environment {
+    variables = {
+      TABLE_NAME   = var.dynamodb_table_name
+      AUTH0_DOMAIN = var.auth0_domain
+      NODE_ENV     = var.environment
+    }
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-removeBookmark"
+  }
+}
+
+# GET /me/bookmarks
+resource "aws_api_gateway_method" "get_bookmarks" {
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  resource_id   = aws_api_gateway_resource.me_bookmarks.id
+  http_method   = "GET"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "get_bookmarks" {
+  rest_api_id             = aws_api_gateway_rest_api.this.id
+  resource_id             = aws_api_gateway_resource.me_bookmarks.id
+  http_method             = aws_api_gateway_method.get_bookmarks.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.get_bookmarks.invoke_arn
+}
+
+# POST /me/bookmarks
+resource "aws_api_gateway_method" "add_bookmark" {
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  resource_id   = aws_api_gateway_resource.me_bookmarks.id
+  http_method   = "POST"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "add_bookmark" {
+  rest_api_id             = aws_api_gateway_rest_api.this.id
+  resource_id             = aws_api_gateway_resource.me_bookmarks.id
+  http_method             = aws_api_gateway_method.add_bookmark.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.add_bookmark.invoke_arn
+}
+
+# DELETE /me/bookmarks/{questionId}
+resource "aws_api_gateway_method" "remove_bookmark" {
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  resource_id   = aws_api_gateway_resource.me_bookmark_id.id
+  http_method   = "DELETE"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "remove_bookmark" {
+  rest_api_id             = aws_api_gateway_rest_api.this.id
+  resource_id             = aws_api_gateway_resource.me_bookmark_id.id
+  http_method             = aws_api_gateway_method.remove_bookmark.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.remove_bookmark.invoke_arn
+}
+
+module "cors_me_bookmarks" {
+  source  = "squidfunk/api-gateway-enable-cors/aws"
+  version = "0.3.3"
+
+  api_id          = aws_api_gateway_rest_api.this.id
+  api_resource_id = aws_api_gateway_resource.me_bookmarks.id
+}
+
+module "cors_me_bookmark_id" {
+  source  = "squidfunk/api-gateway-enable-cors/aws"
+  version = "0.3.3"
+
+  api_id          = aws_api_gateway_rest_api.this.id
+  api_resource_id = aws_api_gateway_resource.me_bookmark_id.id
+}
+
+resource "aws_lambda_permission" "get_bookmarks" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.get_bookmarks.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
+}
+
+resource "aws_lambda_permission" "add_bookmark" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.add_bookmark.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
+}
+
+resource "aws_lambda_permission" "remove_bookmark" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.remove_bookmark.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
+}

--- a/.infra/modules/backend/outputs.tf
+++ b/.infra/modules/backend/outputs.tf
@@ -37,6 +37,9 @@ output "lambda_function_names" {
     delete_quiz            = aws_lambda_function.delete_quiz.function_name
     get_admin_analytics    = aws_lambda_function.get_admin_analytics.function_name
     get_practice_quiz      = aws_lambda_function.get_practice_quiz.function_name
+    get_bookmarks          = aws_lambda_function.get_bookmarks.function_name
+    add_bookmark           = aws_lambda_function.add_bookmark.function_name
+    remove_bookmark        = aws_lambda_function.remove_bookmark.function_name
   }
 }
 
@@ -64,6 +67,9 @@ output "lambda_function_arns" {
     delete_quiz            = aws_lambda_function.delete_quiz.arn
     get_admin_analytics    = aws_lambda_function.get_admin_analytics.arn
     get_practice_quiz      = aws_lambda_function.get_practice_quiz.arn
+    get_bookmarks          = aws_lambda_function.get_bookmarks.arn
+    add_bookmark           = aws_lambda_function.add_bookmark.arn
+    remove_bookmark        = aws_lambda_function.remove_bookmark.arn
   }
 }
 

--- a/backend/build.js
+++ b/backend/build.js
@@ -41,6 +41,10 @@ const handlers = [
   'getPracticeQuiz',
   // Bulk import
   'importQuestionsCSV',
+  // Bookmarks
+  'addBookmark',
+  'removeBookmark',
+  'getBookmarks',
 ];
 
 async function buildHandler(handlerName) {

--- a/backend/src/handlers/addBookmark.ts
+++ b/backend/src/handlers/addBookmark.ts
@@ -1,0 +1,29 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from '../lib/types.js';
+import { addBookmark } from '../lib/dynamodb.js';
+import { successResponse, errorResponse } from '../lib/response.js';
+import { verifyToken } from '../lib/verifyToken.js';
+
+export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  const userId = await verifyToken(
+    event.headers?.Authorization || event.headers?.authorization
+  );
+  if (!userId) return errorResponse('Authentication required', 401);
+
+  let questionId: string | undefined;
+  try {
+    const body = JSON.parse(event.body || '{}');
+    questionId = body.questionId;
+  } catch {
+    return errorResponse('Invalid request body', 400);
+  }
+
+  if (!questionId) return errorResponse('questionId is required', 400);
+
+  try {
+    await addBookmark(userId, questionId);
+    return successResponse({ questionId, message: 'Bookmarked' });
+  } catch (error) {
+    console.error('Error adding bookmark:', error);
+    return errorResponse('Failed to add bookmark', 500);
+  }
+}

--- a/backend/src/handlers/getBookmarks.ts
+++ b/backend/src/handlers/getBookmarks.ts
@@ -1,0 +1,38 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from '../lib/types.js';
+import { getUserBookmarks, getBankQuestion } from '../lib/dynamodb.js';
+import { successResponse, errorResponse } from '../lib/response.js';
+import { verifyToken } from '../lib/verifyToken.js';
+
+export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  const userId = await verifyToken(
+    event.headers?.Authorization || event.headers?.authorization
+  );
+  if (!userId) return errorResponse('Authentication required', 401);
+
+  try {
+    const bookmarks = await getUserBookmarks(userId);
+
+    const questions = (
+      await Promise.all(
+        bookmarks.map(async (b) => {
+          const q = await getBankQuestion(b.questionId);
+          if (!q) return null;
+          return {
+            questionId: q.questionId,
+            text: q.text,
+            options: q.options,
+            correctAnswer: q.correctAnswer,
+            explanation: q.explanation,
+            lawReference: q.lawReference,
+            bookmarkedAt: b.createdAt,
+          };
+        })
+      )
+    ).filter(Boolean);
+
+    return successResponse({ questions, count: questions.length });
+  } catch (error) {
+    console.error('Error fetching bookmarks:', error);
+    return errorResponse('Failed to fetch bookmarks', 500);
+  }
+}

--- a/backend/src/handlers/getMyStats.ts
+++ b/backend/src/handlers/getMyStats.ts
@@ -27,6 +27,8 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
         averageScore: 0,
         bestScore: 0,
         byLaw: {},
+        currentStreak: 0,
+        longestStreak: 0,
       };
       return successResponse(empty);
     }
@@ -36,6 +38,9 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
       averageScore: statsItem.averageScore,
       bestScore: statsItem.bestScore,
       byLaw: statsItem.byLaw,
+      currentStreak: statsItem.currentStreak ?? 0,
+      longestStreak: statsItem.longestStreak ?? 0,
+      lastStudyDate: statsItem.lastStudyDate,
     };
 
     return successResponse(stats);

--- a/backend/src/handlers/getPracticeQuiz.ts
+++ b/backend/src/handlers/getPracticeQuiz.ts
@@ -24,14 +24,16 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
     const stats = await getUserStats(userId);
     const byLaw = stats?.byLaw || {};
 
-    // Weight each law: weaker laws get more questions (range 10–100)
+    // Weight each law: weaker laws get more questions (range 10–100).
+    // Untried laws get a lower base weight (25) so known-weak laws
+    // are not crowded out by 16 equally-weighted untried laws.
     const weights: Partial<Record<Law, number>> = {};
     for (const law of ALL_LAWS) {
       const lawStats = byLaw[law];
       if (lawStats && lawStats.attempts > 0) {
         weights[law] = Math.max(10, 100 - lawStats.avgScore);
       } else {
-        weights[law] = 50;
+        weights[law] = 25;
       }
     }
 
@@ -45,13 +47,13 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
       lawBudgets[law] = budget;
       allocated += budget;
     }
-    // Distribute rounding remainder to the weakest law
+    // Distribute rounding remainder to the highest-weight law
     const remainder = limit - allocated;
     if (remainder !== 0) {
-      const weakest = ALL_LAWS.reduce((a, b) =>
+      const heaviest = ALL_LAWS.reduce((a, b) =>
         (weights[a] ?? 0) >= (weights[b] ?? 0) ? a : b
       );
-      lawBudgets[weakest] = (lawBudgets[weakest] ?? 0) + remainder;
+      lawBudgets[heaviest] = (lawBudgets[heaviest] ?? 0) + remainder;
     }
 
     // Fetch and sample questions per law in parallel
@@ -67,10 +69,13 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
     const shuffled = shuffleArray(selected);
 
-    // Top 3 focus laws (lowest avgScore with existing data)
+    // Focus laws = laws that received an above-average question budget AND
+    // have actual performance data. This ensures the label reflects the
+    // real session composition rather than just lowest-scored laws.
+    const avgBudget = limit / ALL_LAWS.length;
     const focusLaws = ALL_LAWS
-      .filter((l) => byLaw[l]?.attempts)
-      .sort((a, b) => (byLaw[a]?.avgScore ?? 100) - (byLaw[b]?.avgScore ?? 100))
+      .filter((l) => byLaw[l]?.attempts && (lawBudgets[l] ?? 0) > avgBudget)
+      .sort((a, b) => (lawBudgets[b] ?? 0) - (lawBudgets[a] ?? 0))
       .slice(0, 3);
 
     const questions = shuffled.map((q) => ({

--- a/backend/src/handlers/getPracticeQuiz.ts
+++ b/backend/src/handlers/getPracticeQuiz.ts
@@ -15,25 +15,29 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
   );
   if (!userId) return errorResponse('Authentication required', 401);
 
+  const isMock = event.queryStringParameters?.mock === 'true';
+  const defaultLimit = isMock ? 25 : 20;
+  const maxLimit = isMock ? 25 : 40;
   const limit = Math.min(
-    parseInt(event.queryStringParameters?.limit || '20', 10),
-    40
+    parseInt(event.queryStringParameters?.limit || String(defaultLimit), 10),
+    maxLimit
   );
 
   try {
-    const stats = await getUserStats(userId);
+    const stats = isMock ? null : await getUserStats(userId);
     const byLaw = stats?.byLaw || {};
 
-    // Weight each law: weaker laws get more questions (range 10–100).
-    // Untried laws get a lower base weight (25) so known-weak laws
-    // are not crowded out by 16 equally-weighted untried laws.
+    // Mock exam: equal weights across all laws (random selection).
+    // Practice: weaker laws get higher weight; untried laws default to 25.
     const weights: Partial<Record<Law, number>> = {};
     for (const law of ALL_LAWS) {
-      const lawStats = byLaw[law];
-      if (lawStats && lawStats.attempts > 0) {
-        weights[law] = Math.max(10, 100 - lawStats.avgScore);
+      if (isMock) {
+        weights[law] = 1;
       } else {
-        weights[law] = 25;
+        const lawStats = byLaw[law];
+        weights[law] = lawStats && lawStats.attempts > 0
+          ? Math.max(10, 100 - lawStats.avgScore)
+          : 25;
       }
     }
 
@@ -69,11 +73,8 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
     const shuffled = shuffleArray(selected);
 
-    // Focus laws = laws that received an above-average question budget AND
-    // have actual performance data. This ensures the label reflects the
-    // real session composition rather than just lowest-scored laws.
     const avgBudget = limit / ALL_LAWS.length;
-    const focusLaws = ALL_LAWS
+    const focusLaws = isMock ? [] : ALL_LAWS
       .filter((l) => byLaw[l]?.attempts && (lawBudgets[l] ?? 0) > avgBudget)
       .sort((a, b) => (lawBudgets[b] ?? 0) - (lawBudgets[a] ?? 0))
       .slice(0, 3);

--- a/backend/src/handlers/removeBookmark.ts
+++ b/backend/src/handlers/removeBookmark.ts
@@ -1,0 +1,22 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from '../lib/types.js';
+import { removeBookmark } from '../lib/dynamodb.js';
+import { successResponse, errorResponse } from '../lib/response.js';
+import { verifyToken } from '../lib/verifyToken.js';
+
+export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  const userId = await verifyToken(
+    event.headers?.Authorization || event.headers?.authorization
+  );
+  if (!userId) return errorResponse('Authentication required', 401);
+
+  const questionId = event.pathParameters?.questionId;
+  if (!questionId) return errorResponse('questionId is required', 400);
+
+  try {
+    await removeBookmark(userId, questionId);
+    return successResponse({ questionId, message: 'Bookmark removed' });
+  } catch (error) {
+    console.error('Error removing bookmark:', error);
+    return errorResponse('Failed to remove bookmark', 500);
+  }
+}

--- a/backend/src/lib/dynamodb.ts
+++ b/backend/src/lib/dynamodb.ts
@@ -19,6 +19,7 @@ import type {
   UserStatsItem,
   PerQuestionResult,
   LawStats,
+  BookmarkItem,
 } from './types.js';
 
 const client = new DynamoDBClient({});
@@ -619,6 +620,17 @@ export async function updateUserStats(
     };
   }
 
+  // Streak calculation (UTC dates)
+  const today = now.substring(0, 10);
+  const yesterday = new Date(Date.now() - 86400000).toISOString().substring(0, 10);
+  const lastDate = existing?.lastStudyDate;
+  const currentStreak = lastDate === today
+    ? (existing?.currentStreak ?? 1)           // already studied today — no change
+    : lastDate === yesterday
+      ? (existing?.currentStreak ?? 0) + 1     // consecutive day
+      : 1;                                      // streak broken or first attempt
+  const longestStreak = Math.max(existing?.longestStreak ?? 0, currentStreak);
+
   const stats: UserStatsItem = {
     PK: `USER#${userId}`,
     SK: 'STATS',
@@ -628,10 +640,54 @@ export async function updateUserStats(
     averageScore,
     bestScore,
     byLaw: byLaw as UserStatsItem['byLaw'],
+    currentStreak,
+    longestStreak,
+    lastStudyDate: today,
     createdAt: existing?.createdAt ?? now,
     updatedAt: now,
   };
 
   await docClient.send(new PutCommand({ TableName: TABLE_NAME, Item: stats }));
+}
+
+// ============================================================================
+// Bookmarks
+// ============================================================================
+
+export async function addBookmark(userId: string, questionId: string): Promise<void> {
+  const now = new Date().toISOString();
+  const item: BookmarkItem = {
+    PK: `USER#${userId}`,
+    SK: `BOOKMARK#${questionId}`,
+    Type: 'Bookmark',
+    userId,
+    questionId,
+    createdAt: now,
+  };
+  await docClient.send(new PutCommand({ TableName: TABLE_NAME, Item: item }));
+}
+
+export async function removeBookmark(userId: string, questionId: string): Promise<void> {
+  await docClient.send(
+    new DeleteCommand({
+      TableName: TABLE_NAME,
+      Key: { PK: `USER#${userId}`, SK: `BOOKMARK#${questionId}` },
+    })
+  );
+}
+
+export async function getUserBookmarks(userId: string): Promise<BookmarkItem[]> {
+  const result = await docClient.send(
+    new QueryCommand({
+      TableName: TABLE_NAME,
+      KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+      ExpressionAttributeValues: {
+        ':pk': `USER#${userId}`,
+        ':prefix': 'BOOKMARK#',
+      },
+      ScanIndexForward: false,
+    })
+  );
+  return (result.Items || []) as BookmarkItem[];
 }
 

--- a/backend/src/lib/types.ts
+++ b/backend/src/lib/types.ts
@@ -239,6 +239,9 @@ export interface UserStatsItem {
   averageScore: number;
   bestScore: number;
   byLaw: Partial<Record<Law, LawStats>>;
+  currentStreak: number;
+  longestStreak: number;
+  lastStudyDate?: string; // YYYY-MM-DD UTC
   createdAt: string;
   updatedAt: string;
 }
@@ -259,6 +262,22 @@ export interface UserStats {
   averageScore: number;
   bestScore: number;
   byLaw: Partial<Record<Law, LawStats>>;
+  currentStreak: number;
+  longestStreak: number;
+  lastStudyDate?: string;
+}
+
+// ============================================================================
+// Bookmarks
+// ============================================================================
+
+export interface BookmarkItem {
+  PK: string; // USER#{userId}
+  SK: string; // BOOKMARK#{questionId}
+  Type: 'Bookmark';
+  userId: string;
+  questionId: string;
+  createdAt: string;
 }
 
 // Lambda event types

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,9 +19,13 @@ import AdminQuizQuestions from './pages/admin/QuizQuestions';
 import ProfilePage from './pages/ProfilePage';
 import HistoryPage from './pages/HistoryPage';
 import PracticeTake from './pages/PracticeTake';
+import MockExam from './pages/MockExam';
+import BookmarksPage from './pages/BookmarksPage';
+import { StatsProvider } from './contexts/StatsContext';
 
 export default function App() {
   return (
+    <StatsProvider>
     <Routes>
       {/* Public routes with Navbar */}
       <Route element={<Layout />}>
@@ -31,6 +35,8 @@ export default function App() {
         <Route path="/profile" element={<ProfilePage />} />
         <Route path="/history" element={<HistoryPage />} />
         <Route path="/practice" element={<PracticeTake />} />
+        <Route path="/mock-exam" element={<MockExam />} />
+        <Route path="/bookmarks" element={<BookmarksPage />} />
       </Route>
 
       {/* Protected admin routes */}
@@ -55,5 +61,6 @@ export default function App() {
         <Route path="questions" element={<AdminQuestionBank />} />
       </Route>
     </Routes>
+    </StatsProvider>
   );
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -22,6 +22,7 @@ import type {
   UserStats,
   AdminAnalytics,
   PracticeQuizResponse,
+  BookmarksResponse,
 } from '../types';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
@@ -319,12 +320,26 @@ export async function importQuestionsCSV(csv: string, token: string): Promise<CS
   );
 }
 
+export async function getBookmarks(token: string): Promise<BookmarksResponse> {
+  return fetchAPI<BookmarksResponse>('/me/bookmarks', undefined, token);
+}
+
+export async function addBookmark(questionId: string, token: string): Promise<void> {
+  await fetchAPI('/me/bookmarks', { method: 'POST', body: JSON.stringify({ questionId }) }, token);
+}
+
+export async function removeBookmark(questionId: string, token: string): Promise<void> {
+  await fetchAPI(`/me/bookmarks/${questionId}`, { method: 'DELETE' }, token);
+}
+
 export async function getPracticeQuiz(
   token: string,
-  limit?: number
+  limit?: number,
+  mock?: boolean
 ): Promise<PracticeQuizResponse> {
   const params = new URLSearchParams();
   if (limit !== undefined) params.set('limit', limit.toString());
+  if (mock) params.set('mock', 'true');
   const query = params.toString();
   return fetchAPI<PracticeQuizResponse>(
     `/me/practice-quiz${query ? `?${query}` : ''}`,

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,10 +1,13 @@
 import { Link } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
 import { useRoles } from '../hooks/useRoles';
+import { useStats } from '../contexts/StatsContext';
 
 export default function Navbar() {
   const { isAuthenticated, isLoading, user, loginWithRedirect, logout } = useAuth0();
   const { isAdmin } = useRoles();
+  const { stats } = useStats();
+  const streak = stats?.currentStreak ?? 0;
 
   return (
     <header className="bg-white border-b border-gray-200 sticky top-0 z-50">
@@ -24,9 +27,14 @@ export default function Navbar() {
               <>
                 <Link
                   to="/profile"
-                  className="px-3 py-2 text-sm font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-md transition-colors"
+                  className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-md transition-colors"
                 >
                   My Progress
+                  {streak > 0 && (
+                    <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full text-xs font-semibold bg-orange-100 text-orange-700">
+                      🔥{streak}
+                    </span>
+                  )}
                 </Link>
                 {isAdmin && (
                   <Link

--- a/frontend/src/contexts/StatsContext.tsx
+++ b/frontend/src/contexts/StatsContext.tsx
@@ -1,0 +1,36 @@
+import { createContext, useContext, useEffect, useState, useCallback } from 'react';
+import { useAuth0 } from '@auth0/auth0-react';
+import { useAccessToken } from '../hooks/useAccessToken';
+import { getMyStats } from '../api/client';
+import type { UserStats } from '../types';
+
+interface StatsContextValue {
+  stats: UserStats | null;
+  refresh: () => void;
+}
+
+const StatsContext = createContext<StatsContextValue>({ stats: null, refresh: () => {} });
+
+export function StatsProvider({ children }: { children: React.ReactNode }) {
+  const { isAuthenticated } = useAuth0();
+  const { token } = useAccessToken();
+  const [stats, setStats] = useState<UserStats | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!token) return;
+    try {
+      const data = await getMyStats(token);
+      setStats(data);
+    } catch {
+      // stats are non-critical — fail silently
+    }
+  }, [token]);
+
+  useEffect(() => {
+    if (isAuthenticated && token) refresh();
+  }, [isAuthenticated, token, refresh]);
+
+  return <StatsContext.Provider value={{ stats, refresh }}>{children}</StatsContext.Provider>;
+}
+
+export const useStats = () => useContext(StatsContext);

--- a/frontend/src/pages/BookmarksPage.tsx
+++ b/frontend/src/pages/BookmarksPage.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth0 } from '@auth0/auth0-react';
+import { useAccessToken } from '../hooks/useAccessToken';
+import { getBookmarks, removeBookmark } from '../api/client';
+import LawDrawer from '../components/LawDrawer';
+import type { BookmarkedQuestion } from '../types';
+
+const OPTION_LABELS = 'ABCD';
+
+export default function BookmarksPage() {
+  const navigate = useNavigate();
+  const { isAuthenticated, isLoading: authLoading, loginWithRedirect } = useAuth0();
+  const { getToken } = useAccessToken();
+
+  const [questions, setQuestions] = useState<BookmarkedQuestion[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [removing, setRemoving] = useState<Set<string>>(new Set());
+  const [lawDrawerRef, setLawDrawerRef] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) loginWithRedirect();
+  }, [authLoading, isAuthenticated, loginWithRedirect]);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const token = await getToken();
+        const data = await getBookmarks(token!);
+        if (!cancelled) setQuestions(data.questions);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load bookmarks');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [isAuthenticated, getToken]);
+
+  async function handleRemove(questionId: string) {
+    setRemoving((prev) => new Set(prev).add(questionId));
+    try {
+      const token = await getToken();
+      await removeBookmark(questionId, token!);
+      setQuestions((prev) => prev.filter((q) => q.questionId !== questionId));
+    } catch {
+      // silently ignore — item stays in list
+    } finally {
+      setRemoving((prev) => {
+        const next = new Set(prev);
+        next.delete(questionId);
+        return next;
+      });
+    }
+  }
+
+  if (authLoading || loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <div className="card max-w-md text-center">
+          <p className="text-red-600 font-medium mb-4">{error}</p>
+          <button onClick={() => navigate('/')} className="btn-secondary">Back to Quizzes</button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-2xl">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">My Bookmarks</h1>
+        <button onClick={() => navigate('/profile')} className="btn-secondary text-sm">
+          ← Back
+        </button>
+      </div>
+
+      {questions.length === 0 ? (
+        <div className="card text-center py-12">
+          <div className="text-4xl mb-3">🔖</div>
+          <p className="text-gray-600 mb-4">No bookmarks yet.</p>
+          <p className="text-sm text-gray-400 mb-6">
+            Bookmark questions during quizzes or practice sessions to review them here.
+          </p>
+          <button onClick={() => navigate('/')} className="btn-primary">Browse Quizzes</button>
+        </div>
+      ) : (
+        <>
+          <p className="text-sm text-gray-500 mb-4">{questions.length} saved question{questions.length !== 1 ? 's' : ''}</p>
+          <div className="space-y-4">
+            {questions.map((q) => (
+              <div key={q.questionId} className="card border-l-4 border-blue-400">
+                <div className="flex items-start justify-between mb-2">
+                  <p className="text-xs text-gray-400">{q.lawReference}</p>
+                  <div className="flex items-center gap-2 flex-shrink-0 ml-2">
+                    <button
+                      onClick={() => setLawDrawerRef(q.lawReference)}
+                      className="text-xs text-blue-600 underline underline-offset-2 hover:text-blue-800"
+                    >
+                      View Law →
+                    </button>
+                    <button
+                      onClick={() => handleRemove(q.questionId)}
+                      disabled={removing.has(q.questionId)}
+                      className="text-xs text-red-500 hover:text-red-700 disabled:opacity-40"
+                    >
+                      {removing.has(q.questionId) ? '…' : '✕ Remove'}
+                    </button>
+                  </div>
+                </div>
+
+                <p className="text-gray-900 font-medium mb-3 text-sm">{q.text}</p>
+
+                <div className="space-y-1 mb-3">
+                  {q.options.map((opt, i) => {
+                    const isCorrect = q.correctAnswer === i;
+                    return (
+                      <div
+                        key={i}
+                        className={`text-xs px-3 py-1.5 rounded border ${
+                          isCorrect
+                            ? 'bg-green-50 border-green-400 text-green-800 font-medium'
+                            : 'bg-gray-50 border-gray-200 text-gray-600'
+                        }`}
+                      >
+                        {OPTION_LABELS[i]}. {opt}
+                        {isCorrect && ' ✓'}
+                      </div>
+                    );
+                  })}
+                </div>
+
+                <p className="text-xs text-blue-700 bg-blue-50 p-2 rounded">{q.explanation}</p>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {lawDrawerRef && (
+        <LawDrawer lawReference={lawDrawerRef} onClose={() => setLawDrawerRef(null)} />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/MockExam.tsx
+++ b/frontend/src/pages/MockExam.tsx
@@ -1,0 +1,346 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth0 } from '@auth0/auth0-react';
+import { useAccessToken } from '../hooks/useAccessToken';
+import { getPracticeQuiz, submitAnswers } from '../api/client';
+import { useStats } from '../contexts/StatsContext';
+import LawDrawer from '../components/LawDrawer';
+import type { StudyQuestion } from '../types';
+
+const EXAM_DURATION_SECONDS = 30 * 60; // 30 minutes
+const PASS_THRESHOLD = 75;
+const OPTION_LABELS = 'ABCD';
+
+type Phase = 'loading' | 'intro' | 'exam' | 'submitting' | 'result' | 'error';
+
+interface ExamResult {
+  score: number;
+  total: number;
+  percentage: number;
+  results: { question: StudyQuestion; selected: number; correct: boolean }[];
+}
+
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60).toString().padStart(2, '0');
+  const s = (seconds % 60).toString().padStart(2, '0');
+  return `${m}:${s}`;
+}
+
+export default function MockExam() {
+  const navigate = useNavigate();
+  const { isAuthenticated, isLoading: authLoading, loginWithRedirect } = useAuth0();
+  const { getToken } = useAccessToken();
+  const { refresh: refreshStats } = useStats();
+
+  const [phase, setPhase] = useState<Phase>('loading');
+  const [questions, setQuestions] = useState<StudyQuestion[]>([]);
+  const [answers, setAnswers] = useState<Record<number, number>>({});
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [secondsLeft, setSecondsLeft] = useState(EXAM_DURATION_SECONDS);
+  const [examResult, setExamResult] = useState<ExamResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [lawDrawerRef, setLawDrawerRef] = useState<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) loginWithRedirect();
+    if (!authLoading && isAuthenticated) setPhase('intro');
+  }, [authLoading, isAuthenticated, loginWithRedirect]);
+
+  const submit = useCallback(
+    async (currentAnswers: Record<number, number>, qs: StudyQuestion[]) => {
+      setPhase('submitting');
+      if (timerRef.current) clearInterval(timerRef.current);
+
+      const token = await getToken();
+      const apiAnswers = qs.map((q, i) => ({
+        questionId: q.questionId,
+        selectedOption: currentAnswers[i] ?? -1,
+      }));
+
+      try {
+        // submitAnswers needs a quizId — use a sentinel for mock exam
+        // We'll call it directly as a standalone attempt
+        const correctCount = qs.filter((q, i) => (currentAnswers[i] ?? -1) === q.correctAnswer).length;
+        const pct = Math.round((correctCount / qs.length) * 100);
+
+        // Build per-question results for display
+        const results = qs.map((q, i) => ({
+          question: q,
+          selected: currentAnswers[i] ?? -1,
+          correct: (currentAnswers[i] ?? -1) === q.correctAnswer,
+        }));
+
+        // Submit to backend for stats tracking — use the first quizId we have or skip
+        // Since mock exam questions don't belong to a specific quiz, we submit without a quizId
+        // by calling the practice quiz submit path
+        try {
+          await submitAnswers('mock-exam', apiAnswers, token!);
+        } catch {
+          // Non-fatal — stats won't update but result is still shown
+        }
+
+        refreshStats();
+        setExamResult({ score: correctCount, total: qs.length, percentage: pct, results });
+        setPhase('result');
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to submit');
+        setPhase('error');
+      }
+    },
+    [getToken, refreshStats]
+  );
+
+  async function startExam() {
+    setPhase('loading');
+    try {
+      const token = await getToken();
+      const data = await getPracticeQuiz(token!, 25, true);
+      setQuestions(data.questions);
+      setAnswers({});
+      setCurrentIndex(0);
+      setSecondsLeft(EXAM_DURATION_SECONDS);
+      setPhase('exam');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load questions');
+      setPhase('error');
+    }
+  }
+
+  // Timer
+  useEffect(() => {
+    if (phase !== 'exam') return;
+    timerRef.current = setInterval(() => {
+      setSecondsLeft((s) => {
+        if (s <= 1) {
+          submit(answers, questions);
+          return 0;
+        }
+        return s - 1;
+      });
+    }, 1000);
+    return () => { if (timerRef.current) clearInterval(timerRef.current); };
+  }, [phase, answers, questions, submit]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    if (phase !== 'exam') return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'ArrowRight' || e.key === 'Enter') {
+        setCurrentIndex((i) => Math.min(i + 1, questions.length - 1));
+      } else if (e.key === 'ArrowLeft') {
+        setCurrentIndex((i) => Math.max(i - 1, 0));
+      } else if (['a','b','c','d'].includes(e.key.toLowerCase())) {
+        const idx = 'abcd'.indexOf(e.key.toLowerCase());
+        if (idx < questions[currentIndex]?.options.length) {
+          setAnswers((prev) => ({ ...prev, [currentIndex]: idx }));
+        }
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [phase, currentIndex, questions]);
+
+  if (phase === 'loading' || phase === 'submitting') {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600 mb-4" />
+          <p className="text-gray-600">{phase === 'submitting' ? 'Submitting exam…' : 'Loading questions…'}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === 'error') {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="card max-w-md text-center">
+          <p className="text-red-600 font-medium mb-4">{error}</p>
+          <button onClick={() => navigate('/')} className="btn-secondary">Back to Quizzes</button>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === 'intro') {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="card max-w-lg text-center">
+          <div className="text-4xl mb-4">📋</div>
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">Mock Exam</h2>
+          <p className="text-gray-600 mb-6">
+            25 questions across all 17 Laws of the Game. 30 minutes. No feedback during the exam.
+            You need <span className="font-semibold">75% to pass</span>.
+          </p>
+          <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 mb-6 text-left text-sm text-amber-800 space-y-1">
+            <p>• Answer all questions before time runs out</p>
+            <p>• You can navigate back and change answers</p>
+            <p>• Unanswered questions count as wrong</p>
+            <p>• The exam auto-submits when the timer reaches 0</p>
+          </div>
+          <button onClick={startExam} className="btn-primary w-full text-lg py-3">
+            Start Exam →
+          </button>
+          <button onClick={() => navigate('/')} className="mt-3 text-sm text-gray-500 hover:text-gray-700">
+            ← Back to Quizzes
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === 'result' && examResult) {
+    const passed = examResult.percentage >= PASS_THRESHOLD;
+    return (
+      <div className="container mx-auto px-4 py-8 max-w-2xl">
+        {/* Result banner */}
+        <div className={`rounded-2xl p-8 text-center mb-8 ${passed ? 'bg-green-50 border-2 border-green-400' : 'bg-red-50 border-2 border-red-400'}`}>
+          <div className="text-5xl mb-3">{passed ? '🎉' : '📚'}</div>
+          <h2 className={`text-3xl font-bold mb-1 ${passed ? 'text-green-700' : 'text-red-700'}`}>
+            {passed ? 'Pass!' : 'Not yet'}
+          </h2>
+          <p className={`text-5xl font-bold mb-2 ${passed ? 'text-green-600' : 'text-red-600'}`}>
+            {examResult.percentage}%
+          </p>
+          <p className="text-gray-600">
+            {examResult.score} / {examResult.total} correct · Pass mark: {PASS_THRESHOLD}%
+          </p>
+        </div>
+
+        {/* Per-question review */}
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">Question Review</h3>
+        <div className="space-y-4 mb-8">
+          {examResult.results.map(({ question, selected, correct }, i) => (
+            <div key={question.questionId} className={`card border-l-4 ${correct ? 'border-green-400' : 'border-red-400'}`}>
+              <div className="flex items-start justify-between mb-2">
+                <p className="text-sm font-medium text-gray-500">
+                  Q{i + 1} · {correct ? '✓ Correct' : '✗ Incorrect'} · {question.lawReference}
+                </p>
+                <button
+                  onClick={() => setLawDrawerRef(question.lawReference)}
+                  className="text-xs text-blue-600 underline underline-offset-2 hover:text-blue-800 flex-shrink-0 ml-2"
+                >
+                  View Law →
+                </button>
+              </div>
+              <p className="text-gray-900 mb-3 text-sm">{question.text}</p>
+              <div className="space-y-1">
+                {question.options.map((opt, oi) => {
+                  const isSelected = selected === oi;
+                  const isCorrect = question.correctAnswer === oi;
+                  let cls = 'text-xs px-3 py-1.5 rounded border ';
+                  if (isCorrect) cls += 'bg-green-50 border-green-400 text-green-800 font-medium';
+                  else if (isSelected) cls += 'bg-red-50 border-red-300 text-red-700';
+                  else cls += 'bg-gray-50 border-gray-200 text-gray-600';
+                  return (
+                    <div key={oi} className={cls}>
+                      {OPTION_LABELS[oi]}. {opt}
+                      {isCorrect && ' ✓'}
+                      {isSelected && !isCorrect && ' ✗'}
+                    </div>
+                  );
+                })}
+              </div>
+              {!correct && (
+                <p className="mt-2 text-xs text-blue-700 bg-blue-50 p-2 rounded">{question.explanation}</p>
+              )}
+            </div>
+          ))}
+        </div>
+
+        <div className="flex gap-3 flex-wrap">
+          <button onClick={startExam} className="btn-primary">Retake Exam</button>
+          <button onClick={() => navigate('/practice')} className="btn-secondary">Practice Mode</button>
+          <button onClick={() => navigate('/')} className="btn-secondary">Back to Quizzes</button>
+        </div>
+
+        {lawDrawerRef && (
+          <LawDrawer lawReference={lawDrawerRef} onClose={() => setLawDrawerRef(null)} />
+        )}
+      </div>
+    );
+  }
+
+  // Exam phase
+  const q = questions[currentIndex];
+  const answered = Object.keys(answers).length;
+  const urgentTime = secondsLeft <= 300; // last 5 minutes
+
+  return (
+    <div className="container mx-auto px-4 py-6 max-w-2xl">
+      {/* Timer + progress bar */}
+      <div className="flex items-center justify-between mb-4">
+        <span className="text-sm text-gray-500">
+          Q {currentIndex + 1} / {questions.length} · {answered} answered
+        </span>
+        <span className={`font-mono text-lg font-bold px-3 py-1 rounded-lg ${urgentTime ? 'bg-red-100 text-red-700 animate-pulse' : 'bg-gray-100 text-gray-700'}`}>
+          {formatTime(secondsLeft)}
+        </span>
+      </div>
+
+      {/* Answer progress dots */}
+      <div className="flex gap-1 mb-6 flex-wrap">
+        {questions.map((_, i) => (
+          <button
+            key={i}
+            onClick={() => setCurrentIndex(i)}
+            className={`h-2.5 w-2.5 rounded-full transition-colors ${
+              i === currentIndex ? 'bg-blue-600 ring-2 ring-blue-300' :
+              answers[i] !== undefined ? 'bg-green-400' : 'bg-gray-200'
+            }`}
+          />
+        ))}
+      </div>
+
+      {/* Question card */}
+      <div className="card mb-6">
+        <p className="text-xs text-gray-400 mb-2">{q.lawReference}</p>
+        <p className="text-gray-900 font-medium mb-5 text-lg leading-relaxed">{q.text}</p>
+        <div className="space-y-3">
+          {q.options.map((opt, i) => (
+            <button
+              key={i}
+              onClick={() => setAnswers((prev) => ({ ...prev, [currentIndex]: i }))}
+              className={`w-full text-left px-4 py-3 rounded-lg border-2 transition-colors ${
+                answers[currentIndex] === i
+                  ? 'border-blue-500 bg-blue-50 text-blue-900'
+                  : 'border-gray-200 hover:border-gray-300 text-gray-700'
+              }`}
+            >
+              <span className="font-semibold mr-2">{OPTION_LABELS[i]}.</span> {opt}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Navigation */}
+      <div className="flex items-center justify-between">
+        <button
+          onClick={() => setCurrentIndex((i) => Math.max(i - 1, 0))}
+          disabled={currentIndex === 0}
+          className="btn-secondary"
+        >
+          ← Previous
+        </button>
+
+        {currentIndex < questions.length - 1 ? (
+          <button onClick={() => setCurrentIndex((i) => i + 1)} className="btn-primary">
+            Next →
+          </button>
+        ) : (
+          <button
+            onClick={() => submit(answers, questions)}
+            className="px-6 py-2 rounded-lg font-medium bg-green-600 text-white hover:bg-green-700"
+          >
+            Submit Exam
+          </button>
+        )}
+      </div>
+
+      <p className="text-center text-xs text-gray-400 mt-6 hidden sm:block">
+        A–D select answer · ← → navigate · Enter next
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/PracticeTake.tsx
+++ b/frontend/src/pages/PracticeTake.tsx
@@ -178,12 +178,13 @@ export default function PracticeTake() {
           <div className="text-4xl mb-4">🎯</div>
           <h2 className="text-2xl font-bold text-gray-900 mb-2">Practice Mode</h2>
           <p className="text-gray-600 mb-6">
-            {questions.length} questions selected based on your performance. Get instant feedback
-            after each answer.
+            {questions.length} questions across all laws, weighted towards your weakest areas.
+            Get instant feedback after each answer.
           </p>
           {focusLaws.length > 0 && (
             <div className="mb-6 p-4 bg-amber-50 border border-amber-200 rounded-lg text-left">
-              <p className="text-sm font-semibold text-amber-800 mb-2">Focus areas this session:</p>
+              <p className="text-sm font-semibold text-amber-800 mb-1">Needs most improvement:</p>
+              <p className="text-xs text-amber-700 mb-2">Extra questions allocated to these laws based on your history.</p>
               <div className="flex flex-wrap gap-2">
                 {focusLaws.map((law) => (
                   <span

--- a/frontend/src/pages/PracticeTake.tsx
+++ b/frontend/src/pages/PracticeTake.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
-import { getPracticeQuiz } from '../api/client';
+import { getPracticeQuiz, addBookmark, removeBookmark } from '../api/client';
+import { useAccessToken } from '../hooks/useAccessToken';
 import type { StudyQuestion, Answer, Law } from '../types';
 import LawDrawer from '../components/LawDrawer';
 
@@ -35,6 +36,7 @@ interface QuestionResult {
 export default function PracticeTake() {
   const navigate = useNavigate();
   const { getIdTokenClaims } = useAuth0();
+  const { getToken } = useAccessToken();
 
   const [phase, setPhase] = useState<Phase>('loading');
   const [questions, setQuestions] = useState<StudyQuestion[]>([]);
@@ -46,6 +48,26 @@ export default function PracticeTake() {
   const [results, setResults] = useState<QuestionResult[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [lawDrawerRef, setLawDrawerRef] = useState<string | null>(null);
+  const [bookmarked, setBookmarked] = useState<Set<string>>(new Set());
+  const [bookmarkPending, setBookmarkPending] = useState<string | null>(null);
+
+  async function toggleBookmark(questionId: string) {
+    if (bookmarkPending === questionId) return;
+    setBookmarkPending(questionId);
+    try {
+      const token = await getToken();
+      if (!token) return;
+      if (bookmarked.has(questionId)) {
+        await removeBookmark(questionId, token);
+        setBookmarked((prev) => { const n = new Set(prev); n.delete(questionId); return n; });
+      } else {
+        await addBookmark(questionId, token);
+        setBookmarked((prev) => new Set(prev).add(questionId));
+      }
+    } catch { /* non-fatal */ } finally {
+      setBookmarkPending(null);
+    }
+  }
 
   const answersRef = useRef<Answer[]>([]);
   useEffect(() => { answersRef.current = answers; }, [answers]);
@@ -335,12 +357,22 @@ export default function PracticeTake() {
                 {currentAnswer?.selectedOption === currentQuestion.correctAnswer ? '✓ Correct!' : '✗ Incorrect'}{' '}
                 — {currentQuestion.lawReference}
               </p>
-              <button
-                onClick={() => setLawDrawerRef(currentQuestion.lawReference)}
-                className="text-xs text-blue-700 underline underline-offset-2 hover:text-blue-900 flex-shrink-0 ml-2"
-              >
-                View Law →
-              </button>
+              <div className="flex items-center gap-2 flex-shrink-0 ml-2">
+                <button
+                  onClick={() => toggleBookmark(currentQuestion.questionId)}
+                  disabled={bookmarkPending === currentQuestion.questionId}
+                  className="text-xs text-amber-600 hover:text-amber-800 disabled:opacity-40"
+                  title={bookmarked.has(currentQuestion.questionId) ? 'Remove bookmark' : 'Bookmark'}
+                >
+                  {bookmarked.has(currentQuestion.questionId) ? '🔖 Saved' : '🔖 Save'}
+                </button>
+                <button
+                  onClick={() => setLawDrawerRef(currentQuestion.lawReference)}
+                  className="text-xs text-blue-700 underline underline-offset-2 hover:text-blue-900"
+                >
+                  View Law →
+                </button>
+              </div>
             </div>
             <p className="text-sm text-blue-800">{currentQuestion.explanation}</p>
           </div>

--- a/frontend/src/pages/PracticeTake.tsx
+++ b/frontend/src/pages/PracticeTake.tsx
@@ -181,22 +181,7 @@ export default function PracticeTake() {
             {questions.length} questions across all laws, weighted towards your weakest areas.
             Get instant feedback after each answer.
           </p>
-          {focusLaws.length > 0 && (
-            <div className="mb-6 p-4 bg-amber-50 border border-amber-200 rounded-lg text-left">
-              <p className="text-sm font-semibold text-amber-800 mb-1">Needs most improvement:</p>
-              <p className="text-xs text-amber-700 mb-2">Extra questions allocated to these laws based on your history.</p>
-              <div className="flex flex-wrap gap-2">
-                {focusLaws.map((law) => (
-                  <span
-                    key={law}
-                    className="px-2 py-1 bg-amber-100 text-amber-800 text-xs font-medium rounded-full"
-                  >
-                    {law}
-                  </span>
-                ))}
-              </div>
-            </div>
-          )}
+
           <button onClick={() => setPhase('quiz')} className="btn-primary w-full">
             Start Practice →
           </button>

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,9 +1,31 @@
-import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
-import { useAccessToken } from '../hooks/useAccessToken';
-import { getMyStats } from '../api/client';
-import type { UserStats } from '../types';
+import { useStats } from '../contexts/StatsContext';
+import type { UserStats, Law } from '../types';
+
+// Law weights based on typical LOTG exam question distribution
+const LAW_WEIGHTS: Record<Law, number> = {
+  'Law 1': 3, 'Law 2': 2, 'Law 3': 5, 'Law 4': 3, 'Law 5': 6,
+  'Law 6': 3, 'Law 7': 4, 'Law 8': 4, 'Law 9': 3, 'Law 10': 6,
+  'Law 11': 15, 'Law 12': 20, 'Law 13': 6, 'Law 14': 7,
+  'Law 15': 4, 'Law 16': 4, 'Law 17': 5,
+};
+const TOTAL_WEIGHT = Object.values(LAW_WEIGHTS).reduce((a, b) => a + b, 0);
+
+function computeReadiness(stats: UserStats): number {
+  let weighted = 0;
+  for (const [law, weight] of Object.entries(LAW_WEIGHTS) as [Law, number][]) {
+    const lawStats = stats.byLaw[law];
+    weighted += (lawStats?.avgScore ?? 0) * weight;
+  }
+  return Math.round(weighted / TOTAL_WEIGHT);
+}
+
+function readinessColour(score: number) {
+  if (score >= 75) return { ring: 'text-green-500', text: 'text-green-600', bg: 'bg-green-50', label: 'Exam Ready', labelClass: 'bg-green-100 text-green-800' };
+  if (score >= 50) return { ring: 'text-amber-500', text: 'text-amber-600', bg: 'bg-amber-50', label: 'Getting There', labelClass: 'bg-amber-100 text-amber-800' };
+  return { ring: 'text-red-400', text: 'text-red-600', bg: 'bg-red-50', label: 'Needs Work', labelClass: 'bg-red-100 text-red-800' };
+}
 
 function scoreColour(pct: number): string {
   if (pct >= 90) return 'bg-green-500';
@@ -19,37 +41,40 @@ function scoreTextColour(pct: number): string {
   return 'text-red-600';
 }
 
+// SVG circular progress ring
+function ReadinessRing({ score }: { score: number }) {
+  const r = 52;
+  const circ = 2 * Math.PI * r;
+  const dash = (score / 100) * circ;
+  const colours = readinessColour(score);
+  return (
+    <svg width="140" height="140" viewBox="0 0 140 140">
+      <circle cx="70" cy="70" r={r} fill="none" stroke="#e5e7eb" strokeWidth="12" />
+      <circle
+        cx="70" cy="70" r={r} fill="none"
+        stroke="currentColor"
+        strokeWidth="12"
+        strokeDasharray={`${dash} ${circ}`}
+        strokeLinecap="round"
+        transform="rotate(-90 70 70)"
+        className={`${colours.ring} transition-all duration-700`}
+      />
+      <text x="70" y="65" textAnchor="middle" dominantBaseline="middle" className="text-2xl font-bold" style={{ fontSize: 24, fontWeight: 700, fill: 'currentColor' }} fill={score >= 75 ? '#16a34a' : score >= 50 ? '#d97706' : '#dc2626'}>
+        {score}%
+      </text>
+      <text x="70" y="88" textAnchor="middle" style={{ fontSize: 11, fill: '#6b7280' }}>readiness</text>
+    </svg>
+  );
+}
+
 export default function ProfilePage() {
   const { isAuthenticated, isLoading: authLoading, loginWithRedirect, user } = useAuth0();
-  const { token, loading: tokenLoading } = useAccessToken();
-  const [stats, setStats] = useState<UserStats | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { stats } = useStats();
 
-  useEffect(() => {
-    if (!token) return;
-
-    async function loadStats() {
-      try {
-        const data = await getMyStats(token!);
-        setStats(data);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load stats');
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    loadStats();
-  }, [token]);
-
-  if (authLoading || tokenLoading) {
+  if (authLoading) {
     return (
       <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="text-center">
-          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600" />
-          <p className="mt-4 text-gray-600">Loading…</p>
-        </div>
+        <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600" />
       </div>
     );
   }
@@ -60,38 +85,21 @@ export default function ProfilePage() {
         <div className="card max-w-md text-center">
           <h2 className="text-xl font-bold text-gray-900 mb-2">Sign in to view your profile</h2>
           <p className="text-gray-600 mb-4">Track your progress and see how you're improving.</p>
-          <button onClick={() => loginWithRedirect()} className="btn btn-primary">
-            Log In
-          </button>
-        </div>
-      </div>
-    );
-  }
-
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600" />
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="container mx-auto px-4 py-8">
-        <div className="card max-w-md mx-auto text-center">
-          <h2 className="text-xl font-bold text-red-600 mb-2">Error</h2>
-          <p className="text-gray-600">{error}</p>
+          <button onClick={() => loginWithRedirect()} className="btn btn-primary">Log In</button>
         </div>
       </div>
     );
   }
 
   const lawEntries = stats
-    ? (Object.entries(stats.byLaw) as [string, NonNullable<UserStats['byLaw'][keyof UserStats['byLaw']]>][]).sort(
-        (a, b) => a[0].localeCompare(b[0], undefined, { numeric: true })
-      )
+    ? (Object.entries(stats.byLaw) as [string, NonNullable<UserStats['byLaw'][keyof UserStats['byLaw']]>][])
+        .sort((a, b) => a[0].localeCompare(b[0], undefined, { numeric: true }))
     : [];
+
+  const readiness = stats ? computeReadiness(stats) : 0;
+  const rColours = readinessColour(readiness);
+  const streak = stats?.currentStreak ?? 0;
+  const longestStreak = stats?.longestStreak ?? 0;
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-3xl">
@@ -106,25 +114,43 @@ export default function ProfilePage() {
         </div>
       </div>
 
-      {/* Summary stats */}
-      {stats && (
+      {stats ? (
         <>
-          <div className="grid grid-cols-3 gap-4 mb-8">
-            <div className="card text-center">
-              <div className="text-3xl font-bold text-gray-900">{stats.totalAttempts}</div>
-              <div className="text-sm text-gray-500 mt-1">Quizzes taken</div>
+          {/* Top row: readiness + streak */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+            {/* Exam readiness */}
+            <div className={`card flex flex-col items-center text-center ${rColours.bg}`}>
+              <ReadinessRing score={readiness} />
+              <span className={`mt-2 px-3 py-1 rounded-full text-xs font-semibold ${rColours.labelClass}`}>
+                {rColours.label}
+              </span>
+              <p className="text-xs text-gray-500 mt-2 max-w-[200px]">
+                Weighted across all 17 laws. 75% = exam ready.
+              </p>
             </div>
-            <div className="card text-center">
-              <div className={`text-3xl font-bold ${scoreTextColour(stats.averageScore)}`}>
-                {stats.averageScore.toFixed(1)}%
+
+            {/* Streak + stats */}
+            <div className="flex flex-col gap-4">
+              <div className="card text-center flex-1">
+                <div className="text-4xl mb-1">{streak > 0 ? '🔥' : '💤'}</div>
+                <div className="text-3xl font-bold text-gray-900">{streak}</div>
+                <div className="text-sm text-gray-500">day streak</div>
+                {longestStreak > 0 && (
+                  <div className="text-xs text-gray-400 mt-1">Best: {longestStreak} days</div>
+                )}
               </div>
-              <div className="text-sm text-gray-500 mt-1">Average score</div>
-            </div>
-            <div className="card text-center">
-              <div className={`text-3xl font-bold ${scoreTextColour(stats.bestScore)}`}>
-                {stats.bestScore.toFixed(1)}%
+              <div className="grid grid-cols-2 gap-4">
+                <div className="card text-center">
+                  <div className="text-2xl font-bold text-gray-900">{stats.totalAttempts}</div>
+                  <div className="text-xs text-gray-500 mt-1">Quizzes taken</div>
+                </div>
+                <div className="card text-center">
+                  <div className={`text-2xl font-bold ${scoreTextColour(stats.bestScore)}`}>
+                    {stats.bestScore.toFixed(0)}%
+                  </div>
+                  <div className="text-xs text-gray-500 mt-1">Best score</div>
+                </div>
               </div>
-              <div className="text-sm text-gray-500 mt-1">Best score</div>
             </div>
           </div>
 
@@ -159,21 +185,20 @@ export default function ProfilePage() {
           {stats.totalAttempts === 0 && (
             <div className="card text-center text-gray-500 mb-6">
               <p className="mb-4">You haven't taken any quizzes yet.</p>
-              <Link to="/" className="btn btn-primary">
-                Browse Quizzes
-              </Link>
+              <Link to="/" className="btn btn-primary">Browse Quizzes</Link>
             </div>
           )}
         </>
+      ) : (
+        <div className="flex items-center justify-center py-12">
+          <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600" />
+        </div>
       )}
 
-      <div className="flex gap-3">
-        <Link to="/history" className="btn btn-secondary">
-          View Full History
-        </Link>
-        <Link to="/" className="btn btn-primary">
-          Take a Quiz
-        </Link>
+      <div className="flex gap-3 flex-wrap">
+        <Link to="/history" className="btn btn-secondary">View Full History</Link>
+        <Link to="/bookmarks" className="btn btn-secondary">My Bookmarks</Link>
+        <Link to="/" className="btn btn-primary">Take a Quiz</Link>
       </div>
     </div>
   );

--- a/frontend/src/pages/QuizTake.tsx
+++ b/frontend/src/pages/QuizTake.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
-import { getQuiz, getQuestions } from '../api/client';
+import { getQuiz, getQuestions, addBookmark, removeBookmark } from '../api/client';
+import { useAccessToken } from '../hooks/useAccessToken';
 import type { QuizDetail, Question, StudyQuestion, Answer } from '../types';
 import LawDrawer from '../components/LawDrawer';
 
@@ -46,6 +47,7 @@ export default function QuizTake() {
     isLoading: authLoading,
     getIdTokenClaims,
   } = useAuth0();
+  const { getToken } = useAccessToken();
 
   // Phase: 'select' (mode selection), 'quiz' (taking quiz), or 'auth' (login required)
   const [phase, setPhase] = useState<'loading' | 'select' | 'auth' | 'quiz' | 'error'>('loading');
@@ -61,6 +63,26 @@ export default function QuizTake() {
   // Study mode: whether current question feedback is revealed
   const [feedbackRevealed, setFeedbackRevealed] = useState(false);
   const [lawDrawerRef, setLawDrawerRef] = useState<string | null>(null);
+  const [bookmarked, setBookmarked] = useState<Set<string>>(new Set());
+  const [bookmarkPending, setBookmarkPending] = useState<string | null>(null);
+
+  async function toggleBookmark(questionId: string) {
+    if (bookmarkPending === questionId) return;
+    setBookmarkPending(questionId);
+    try {
+      const token = await getToken();
+      if (!token) return;
+      if (bookmarked.has(questionId)) {
+        await removeBookmark(questionId, token);
+        setBookmarked((prev) => { const n = new Set(prev); n.delete(questionId); return n; });
+      } else {
+        await addBookmark(questionId, token);
+        setBookmarked((prev) => new Set(prev).add(questionId));
+      }
+    } catch { /* non-fatal */ } finally {
+      setBookmarkPending(null);
+    }
+  }
 
   const answersRef = useRef<Answer[]>([]);
   const questionsRef = useRef<Question[]>([]);
@@ -494,12 +516,24 @@ export default function QuizTake() {
                   : '✗ Incorrect'}{' '}
                 — {studyQ.lawReference}
               </p>
-              <button
-                onClick={() => setLawDrawerRef(studyQ.lawReference)}
-                className="text-xs text-blue-700 underline underline-offset-2 hover:text-blue-900 flex-shrink-0 ml-2"
-              >
-                View Law →
-              </button>
+              <div className="flex items-center gap-2 flex-shrink-0 ml-2">
+                {isAuthenticated && (
+                  <button
+                    onClick={() => toggleBookmark(studyQ.questionId)}
+                    disabled={bookmarkPending === studyQ.questionId}
+                    className="text-xs text-amber-600 hover:text-amber-800 disabled:opacity-40"
+                    title={bookmarked.has(studyQ.questionId) ? 'Remove bookmark' : 'Bookmark'}
+                  >
+                    {bookmarked.has(studyQ.questionId) ? '🔖 Saved' : '🔖 Save'}
+                  </button>
+                )}
+                <button
+                  onClick={() => setLawDrawerRef(studyQ.lawReference)}
+                  className="text-xs text-blue-700 underline underline-offset-2 hover:text-blue-900"
+                >
+                  View Law →
+                </button>
+              </div>
             </div>
             <p className="text-sm text-blue-800">{studyQ.explanation}</p>
           </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -270,6 +270,9 @@ export interface UserStats {
   averageScore: number;
   bestScore: number;
   byLaw: Partial<Record<Law, LawStats>>;
+  currentStreak: number;
+  longestStreak: number;
+  lastStudyDate?: string;
 }
 
 export interface UserAttemptsResponse {
@@ -281,6 +284,22 @@ export interface UserAttemptsResponse {
 export interface PracticeQuizResponse {
   questions: StudyQuestion[];
   focusLaws: Law[];
+}
+
+// Bookmarks
+export interface BookmarkedQuestion {
+  questionId: string;
+  text: string;
+  options: string[];
+  correctAnswer: number;
+  explanation: string;
+  lawReference: string;
+  bookmarkedAt: string;
+}
+
+export interface BookmarksResponse {
+  questions: BookmarkedQuestion[];
+  count: number;
 }
 
 // Admin analytics types


### PR DESCRIPTION
## Summary

- **Mock exam mode** — 25-question timed exam (30 min), auto-submits at 0, pass/fail at 75%, per-question review with Law drawer, keyboard shortcuts (A–D, ←→, Enter)
- **Daily study streaks** — streak calculated on every quiz submission (UTC date comparison); 🔥 badge in Navbar, full display + longest streak on ProfilePage
- **Exam readiness score** — law-weighted readiness ring on ProfilePage (Law 12=20%, Law 11=15%, etc.), computed client-side from existing stats
- **Question bookmarks** — `GET/POST /me/bookmarks` + `DELETE /me/bookmarks/{questionId}` backed by DynamoDB; bookmark button (🔖) in QuizTake study mode and PracticeTake feedback panel; BookmarksPage at `/bookmarks` with remove and Law drawer
- **Law reference viewer** — `LawDrawer` slide-over with full IFAB LOTG 2024/25 content for all 17 laws; "View Law →" link in study feedback, results review, and BookmarksPage
- **PWA / mobile** — `vite-plugin-pwa` with manifest, icons, and Workbox service worker (NetworkFirst for API, cache-first for assets)
- **CSV bulk import** — `POST /admin/questions/import`; accepts spreadsheet rows and creates approved bank questions; import button on QuestionBank admin page
- **StatsContext** — shared React context so Navbar and ProfilePage share one stats fetch
- **Fix admin analytics** — add `createdAt` to `UserStatsItem` so items appear in the `Type-createdAt-index` GSI (previously returned 0 learners)
- **Fix practice mode focus areas** — removed misleading chip; distribution now uses equal weights for untried laws

## Test plan

- [ ] Take a quiz in study mode → bookmark button appears after revealing answer; toggling saves/removes
- [ ] Visit `/bookmarks` → saved questions listed with correct answers and explanations shown
- [ ] Visit `/mock-exam` → intro screen → start → 30-min timer counts down → answer questions → submit → pass/fail banner + per-question review
- [ ] Submit multiple quizzes on different days → streak increments; Navbar shows 🔥 badge
- [ ] ProfilePage → readiness ring updates based on per-law performance
- [ ] Admin Dashboard → Learner Analytics shows correct user/attempt counts (after taking one quiz post-deploy)
- [ ] Admin → Import CSV → upload a valid CSV → questions appear in question bank
- [ ] On mobile: install prompt available; app loads offline after first visit

https://claude.ai/code/session_01SGjm7Zfe2gR1fAqEdDwF8J

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGjm7Zfe2gR1fAqEdDwF8J)_