### PR TITLE
feat(admin): surface PDF-import duplicate conflicts for admin review

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -162,6 +162,8 @@ jobs:
       lambda_review_question: ${{ steps.tf-output.outputs.lambda_review_question }}
       lambda_bulk_review_questions: ${{ steps.tf-output.outputs.lambda_bulk_review_questions }}
       lambda_update_question: ${{ steps.tf-output.outputs.lambda_update_question }}
+      lambda_list_conflicts: ${{ steps.tf-output.outputs.lambda_list_conflicts }}
+      lambda_resolve_conflict: ${{ steps.tf-output.outputs.lambda_resolve_conflict }}
       lambda_get_extraction_jobs: ${{ steps.tf-output.outputs.lambda_get_extraction_jobs }}
       lambda_publish_quiz: ${{ steps.tf-output.outputs.lambda_publish_quiz }}
       lambda_create_manual_job: ${{ steps.tf-output.outputs.lambda_create_manual_job }}
@@ -210,6 +212,8 @@ jobs:
           echo "lambda_review_question=$(terraform output -json lambda_function_names | jq -r '.review_question')" >> $GITHUB_OUTPUT
           echo "lambda_bulk_review_questions=$(terraform output -json lambda_function_names | jq -r '.bulk_review_questions')" >> $GITHUB_OUTPUT
           echo "lambda_update_question=$(terraform output -json lambda_function_names | jq -r '.update_question')" >> $GITHUB_OUTPUT
+          echo "lambda_list_conflicts=$(terraform output -json lambda_function_names | jq -r '.list_conflicts')" >> $GITHUB_OUTPUT
+          echo "lambda_resolve_conflict=$(terraform output -json lambda_function_names | jq -r '.resolve_conflict')" >> $GITHUB_OUTPUT
           echo "lambda_get_extraction_jobs=$(terraform output -json lambda_function_names | jq -r '.get_extraction_jobs')" >> $GITHUB_OUTPUT
           echo "lambda_publish_quiz=$(terraform output -json lambda_function_names | jq -r '.publish_quiz')" >> $GITHUB_OUTPUT
           echo "lambda_create_manual_job=$(terraform output -json lambda_function_names | jq -r '.create_manual_job')" >> $GITHUB_OUTPUT
@@ -303,6 +307,20 @@ jobs:
           aws lambda update-function-code \
             --function-name ${{ needs.get-outputs.outputs.lambda_review_question }} \
             --zip-file fileb://backend/dist/reviewQuestion.zip
+
+      - name: Update Lambda - listConflicts
+        if: needs.get-outputs.outputs.lambda_list_conflicts != '' && needs.get-outputs.outputs.lambda_list_conflicts != 'null'
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ needs.get-outputs.outputs.lambda_list_conflicts }} \
+            --zip-file fileb://backend/dist/listConflicts.zip
+
+      - name: Update Lambda - resolveConflict
+        if: needs.get-outputs.outputs.lambda_resolve_conflict != '' && needs.get-outputs.outputs.lambda_resolve_conflict != 'null'
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ needs.get-outputs.outputs.lambda_resolve_conflict }} \
+            --zip-file fileb://backend/dist/resolveConflict.zip
 
       - name: Update Lambda - updateQuestion
         if: needs.get-outputs.outputs.lambda_update_question != '' && needs.get-outputs.outputs.lambda_update_question != 'null'

--- a/.infra/modules/backend/main.tf
+++ b/.infra/modules/backend/main.tf
@@ -14,6 +14,8 @@ locals {
     "reviewQuestion",
     "bulkReviewQuestions",
     "updateQuestion",
+    "listConflicts",
+    "resolveConflict",
     "publishQuiz",
     "getExtractionJobs",
     "createManualJob",
@@ -488,6 +490,9 @@ resource "aws_api_gateway_deployment" "this" {
       aws_api_gateway_resource.admin_questions_import.id,
       aws_api_gateway_resource.me_bookmarks.id,
       aws_api_gateway_resource.me_bookmark_id.id,
+      aws_api_gateway_resource.admin_conflicts.id,
+      aws_api_gateway_resource.admin_conflict_id.id,
+      aws_api_gateway_resource.admin_conflict_resolve.id,
       [for r in aws_api_gateway_gateway_response.cors : r.id],
     ]))
   }
@@ -884,6 +889,58 @@ resource "aws_lambda_function" "update_question" {
 }
 
 # ============================================================================
+# Lambda Function: listConflicts
+# ============================================================================
+
+resource "aws_lambda_function" "list_conflicts" {
+  filename         = "${path.module}/../../../backend/dist/listConflicts.zip"
+  function_name    = "${var.project_name}-${var.environment}-listConflicts"
+  role             = aws_iam_role.lambda_admin.arn
+  handler          = "index.handler"
+  runtime          = "nodejs24.x"
+  timeout          = 10
+  memory_size      = 256
+  source_code_hash = fileexists("${path.module}/../../../backend/dist/listConflicts.zip") ? filebase64sha256("${path.module}/../../../backend/dist/listConflicts.zip") : null
+
+  environment {
+    variables = {
+      TABLE_NAME = var.dynamodb_table_name
+      NODE_ENV   = var.environment
+    }
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-listConflicts"
+  }
+}
+
+# ============================================================================
+# Lambda Function: resolveConflict
+# ============================================================================
+
+resource "aws_lambda_function" "resolve_conflict" {
+  filename         = "${path.module}/../../../backend/dist/resolveConflict.zip"
+  function_name    = "${var.project_name}-${var.environment}-resolveConflict"
+  role             = aws_iam_role.lambda_admin.arn
+  handler          = "index.handler"
+  runtime          = "nodejs24.x"
+  timeout          = 10
+  memory_size      = 256
+  source_code_hash = fileexists("${path.module}/../../../backend/dist/resolveConflict.zip") ? filebase64sha256("${path.module}/../../../backend/dist/resolveConflict.zip") : null
+
+  environment {
+    variables = {
+      TABLE_NAME = var.dynamodb_table_name
+      NODE_ENV   = var.environment
+    }
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-resolveConflict"
+  }
+}
+
+# ============================================================================
 # Lambda Function: publishQuiz
 # ============================================================================
 
@@ -1155,6 +1212,63 @@ resource "aws_api_gateway_integration" "bulk_review" {
   uri                     = aws_lambda_function.bulk_review_questions.invoke_arn
 }
 
+# /admin/conflicts
+resource "aws_api_gateway_resource" "admin_conflicts" {
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  parent_id   = aws_api_gateway_resource.admin.id
+  path_part   = "conflicts"
+}
+
+# GET /admin/conflicts - list pending or resolved conflicts
+resource "aws_api_gateway_method" "list_conflicts" {
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  resource_id   = aws_api_gateway_resource.admin_conflicts.id
+  http_method   = "GET"
+  authorization = "CUSTOM"
+  authorizer_id = aws_api_gateway_authorizer.jwt.id
+}
+
+resource "aws_api_gateway_integration" "list_conflicts" {
+  rest_api_id             = aws_api_gateway_rest_api.this.id
+  resource_id             = aws_api_gateway_resource.admin_conflicts.id
+  http_method             = aws_api_gateway_method.list_conflicts.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.list_conflicts.invoke_arn
+}
+
+# /admin/conflicts/{id}
+resource "aws_api_gateway_resource" "admin_conflict_id" {
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  parent_id   = aws_api_gateway_resource.admin_conflicts.id
+  path_part   = "{id}"
+}
+
+# /admin/conflicts/{id}/resolve
+resource "aws_api_gateway_resource" "admin_conflict_resolve" {
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  parent_id   = aws_api_gateway_resource.admin_conflict_id.id
+  path_part   = "resolve"
+}
+
+# POST /admin/conflicts/{id}/resolve
+resource "aws_api_gateway_method" "resolve_conflict" {
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  resource_id   = aws_api_gateway_resource.admin_conflict_resolve.id
+  http_method   = "POST"
+  authorization = "CUSTOM"
+  authorizer_id = aws_api_gateway_authorizer.jwt.id
+}
+
+resource "aws_api_gateway_integration" "resolve_conflict" {
+  rest_api_id             = aws_api_gateway_rest_api.this.id
+  resource_id             = aws_api_gateway_resource.admin_conflict_resolve.id
+  http_method             = aws_api_gateway_method.resolve_conflict.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.resolve_conflict.invoke_arn
+}
+
 # CORS for admin routes
 module "cors_admin" {
   source  = "squidfunk/api-gateway-enable-cors/aws"
@@ -1226,6 +1340,22 @@ module "cors_admin_bulk_review" {
 
   api_id          = aws_api_gateway_rest_api.this.id
   api_resource_id = aws_api_gateway_resource.admin_bulk_review.id
+}
+
+module "cors_admin_conflicts" {
+  source  = "squidfunk/api-gateway-enable-cors/aws"
+  version = "0.3.3"
+
+  api_id          = aws_api_gateway_rest_api.this.id
+  api_resource_id = aws_api_gateway_resource.admin_conflicts.id
+}
+
+module "cors_admin_conflict_resolve" {
+  source  = "squidfunk/api-gateway-enable-cors/aws"
+  version = "0.3.3"
+
+  api_id          = aws_api_gateway_rest_api.this.id
+  api_resource_id = aws_api_gateway_resource.admin_conflict_resolve.id
 }
 
 # ============================================================================
@@ -1537,6 +1667,22 @@ resource "aws_lambda_permission" "bulk_review_questions" {
   statement_id  = "AllowAPIGatewayInvoke"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.bulk_review_questions.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
+}
+
+resource "aws_lambda_permission" "list_conflicts" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.list_conflicts.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
+}
+
+resource "aws_lambda_permission" "resolve_conflict" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.resolve_conflict.function_name
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
 }

--- a/.infra/modules/backend/outputs.tf
+++ b/.infra/modules/backend/outputs.tf
@@ -26,6 +26,8 @@ output "lambda_function_names" {
     review_question        = aws_lambda_function.review_question.function_name
     bulk_review_questions  = aws_lambda_function.bulk_review_questions.function_name
     update_question        = aws_lambda_function.update_question.function_name
+    list_conflicts         = aws_lambda_function.list_conflicts.function_name
+    resolve_conflict       = aws_lambda_function.resolve_conflict.function_name
     get_extraction_jobs    = aws_lambda_function.get_extraction_jobs.function_name
     publish_quiz           = aws_lambda_function.publish_quiz.function_name
     create_manual_job      = aws_lambda_function.create_manual_job.function_name
@@ -57,6 +59,8 @@ output "lambda_function_arns" {
     review_question        = aws_lambda_function.review_question.arn
     update_question        = aws_lambda_function.update_question.arn
     bulk_review_questions  = aws_lambda_function.bulk_review_questions.arn
+    list_conflicts         = aws_lambda_function.list_conflicts.arn
+    resolve_conflict       = aws_lambda_function.resolve_conflict.arn
     get_extraction_jobs    = aws_lambda_function.get_extraction_jobs.arn
     publish_quiz           = aws_lambda_function.publish_quiz.arn
     create_manual_job      = aws_lambda_function.create_manual_job.arn

--- a/backend/build.js
+++ b/backend/build.js
@@ -46,6 +46,9 @@ const handlers = [
   'addBookmark',
   'removeBookmark',
   'getBookmarks',
+  // Import conflict review
+  'listConflicts',
+  'resolveConflict',
 ];
 
 async function buildHandler(handlerName) {

--- a/backend/src/handlers/listConflicts.ts
+++ b/backend/src/handlers/listConflicts.ts
@@ -1,0 +1,36 @@
+import type {
+  APIGatewayProxyEvent,
+  APIGatewayProxyResult,
+  QuestionConflictItem,
+} from '../lib/types.js';
+import { getConflictsByStatus } from '../lib/dynamodb.js';
+import { successResponse, errorResponse } from '../lib/response.js';
+
+/**
+ * GET /admin/conflicts?status=pending|resolved
+ *
+ * Lists question conflicts created during PDF import when an extracted
+ * candidate had the same text+options as an existing bank question but
+ * a different correct answer / explanation / law / lawReference.
+ */
+export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  console.log('Event:', JSON.stringify(event, null, 2));
+
+  const statusParam = event.queryStringParameters?.status;
+  const status: 'pending' | 'resolved' = statusParam === 'resolved' ? 'resolved' : 'pending';
+
+  try {
+    const items = await getConflictsByStatus(status, 100);
+    const conflicts = items.map(stripKeys);
+    return successResponse({ conflicts, count: conflicts.length });
+  } catch (error) {
+    console.error('Error listing conflicts:', error);
+    return errorResponse('Failed to list conflicts', 500);
+  }
+}
+
+function stripKeys(item: QuestionConflictItem) {
+  // Drop the internal PK/SK/Type fields from the API response.
+  const { PK: _pk, SK: _sk, Type: _type, ...rest } = item;
+  return rest;
+}

--- a/backend/src/handlers/processPdf.ts
+++ b/backend/src/handlers/processPdf.ts
@@ -9,12 +9,14 @@ import type {
   BankQuestionItem,
   ExtractionJobItem,
   Law,
+  QuestionConflictItem,
 } from '../lib/types.js';
 import {
   createExtractionJob,
   updateExtractionJob,
   batchSaveBankQuestions,
-  questionExistsByHash,
+  getBankQuestionByHash,
+  saveQuestionConflict,
 } from '../lib/dynamodb.js';
 
 const s3Client = new S3Client({});
@@ -284,17 +286,66 @@ export async function handler(event: S3Event): Promise<void> {
       // Process and deduplicate questions
       const questionsToSave: BankQuestionItem[] = [];
       let duplicateCount = 0;
+      let conflictCount = 0;
       let autoApprovedCount = 0;
       let pendingCount = 0;
 
       for (const extracted of extractedQuestions) {
         const hash = generateQuestionHash(extracted.text, extracted.options);
 
-        // Check for duplicates
-        const isDuplicate = await questionExistsByHash(hash);
-        if (isDuplicate) {
-          duplicateCount++;
-          console.log(`Duplicate question found: ${extracted.text.substring(0, 50)}...`);
+        // Look up any existing question with the same text+options hash.
+        const existing = await getBankQuestionByHash(hash);
+        if (existing) {
+          // Compare the "outcome" fields. If any differ, this is a conflict
+          // worth surfacing for admin review rather than a silent dupe.
+          const diffFields: QuestionConflictItem['diffFields'] = [];
+          if (existing.correctAnswer !== extracted.correctAnswer) diffFields.push('correctAnswer');
+          if ((existing.explanation ?? '') !== (extracted.explanation ?? '')) diffFields.push('explanation');
+          if (existing.law !== extracted.law) diffFields.push('law');
+          if ((existing.lawReference ?? '') !== (extracted.lawReference ?? ''))
+            diffFields.push('lawReference');
+
+          if (diffFields.length === 0) {
+            // True duplicate — same text, options and outcome. Skip silently as before.
+            duplicateCount++;
+            console.log(`Duplicate question found: ${extracted.text.substring(0, 50)}...`);
+            continue;
+          }
+
+          // Outcome differs — record a conflict for admin review and do NOT
+          // create the candidate as a new bank question yet.
+          const conflictId = ulid();
+          const conflict: QuestionConflictItem = {
+            PK: `CONFLICT#${conflictId}`,
+            SK: 'METADATA',
+            Type: 'QuestionConflict',
+            conflictId,
+            status: 'pending',
+            existingQuestionId: existing.questionId,
+            jobId,
+            text: extracted.text,
+            options: extracted.options,
+            existing: {
+              correctAnswer: existing.correctAnswer,
+              explanation: existing.explanation ?? '',
+              law: existing.law,
+              lawReference: existing.lawReference ?? '',
+            },
+            candidate: {
+              correctAnswer: extracted.correctAnswer,
+              explanation: extracted.explanation ?? '',
+              law: extracted.law,
+              lawReference: extracted.lawReference ?? '',
+              confidence: extracted.confidence,
+            },
+            diffFields,
+            createdAt: now,
+          };
+          await saveQuestionConflict(conflict);
+          conflictCount++;
+          console.log(
+            `Conflict on question "${extracted.text.substring(0, 50)}…" diffs=${diffFields.join(',')}`
+          );
           continue;
         }
 
@@ -345,12 +396,13 @@ export async function handler(event: S3Event): Promise<void> {
         pendingCount,
         rejectedCount: 0,
         duplicateCount,
+        conflictCount,
         completedAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
       });
 
       console.log(
-        `Job ${jobId} completed: ${questionsToSave.length} questions saved, ${autoApprovedCount} auto-approved, ${pendingCount} pending review, ${duplicateCount} duplicates`
+        `Job ${jobId} completed: ${questionsToSave.length} questions saved, ${autoApprovedCount} auto-approved, ${pendingCount} pending review, ${duplicateCount} duplicates, ${conflictCount} conflicts`
       );
     } catch (error) {
       console.error(`Error processing job ${jobId}:`, error);

--- a/backend/src/handlers/resolveConflict.ts
+++ b/backend/src/handlers/resolveConflict.ts
@@ -1,0 +1,125 @@
+import { createHash } from 'crypto';
+import { ulid } from 'ulid';
+import type {
+  APIGatewayProxyEvent,
+  APIGatewayProxyResult,
+  BankQuestionItem,
+  ConflictResolution,
+} from '../lib/types.js';
+import {
+  getConflict,
+  getBankQuestion,
+  updateBankQuestionContent,
+  markConflictResolved,
+  batchSaveBankQuestions,
+} from '../lib/dynamodb.js';
+import { successResponse, errorResponse } from '../lib/response.js';
+
+const VALID_RESOLUTIONS: ConflictResolution[] = ['kept_existing', 'replaced', 'kept_both'];
+
+interface ResolveRequest {
+  resolution: ConflictResolution;
+  resolvedBy?: string;
+}
+
+/**
+ * POST /admin/conflicts/{id}/resolve
+ * Body: { resolution: 'kept_existing' | 'replaced' | 'kept_both', resolvedBy?: string }
+ *
+ * - kept_existing: keep the existing bank question as-is; the candidate is
+ *   discarded. The conflict is marked resolved.
+ * - replaced:     overwrite the existing bank question's outcome fields
+ *   (correctAnswer / explanation / law / lawReference) with the candidate's.
+ *   Text and options are unchanged (they already matched by hash).
+ * - kept_both:    insert the candidate as a brand new bank question alongside
+ *   the existing one. The new row gets a discriminated hash so it doesn't
+ *   collide with future dedup checks against the canonical original.
+ */
+export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  console.log('Event:', JSON.stringify(event, null, 2));
+
+  const conflictId = event.pathParameters?.id;
+  if (!conflictId) return errorResponse('Missing conflict ID', 400);
+  if (!event.body) return errorResponse('Request body is required', 400);
+
+  let request: ResolveRequest;
+  try {
+    request = JSON.parse(event.body);
+  } catch {
+    return errorResponse('Invalid JSON body', 400);
+  }
+
+  if (!VALID_RESOLUTIONS.includes(request.resolution)) {
+    return errorResponse(`resolution must be one of: ${VALID_RESOLUTIONS.join(', ')}`, 400);
+  }
+
+  try {
+    const conflict = await getConflict(conflictId);
+    if (!conflict) return errorResponse('Conflict not found', 404);
+    if (conflict.status === 'resolved') {
+      return errorResponse('Conflict has already been resolved', 409);
+    }
+
+    const resolvedBy = request.resolvedBy?.trim() || 'admin';
+
+    if (request.resolution === 'replaced') {
+      const existing = await getBankQuestion(conflict.existingQuestionId);
+      if (!existing) {
+        return errorResponse('Existing question no longer exists', 404);
+      }
+      await updateBankQuestionContent(conflict.existingQuestionId, {
+        correctAnswer: conflict.candidate.correctAnswer,
+        explanation: conflict.candidate.explanation,
+        law: conflict.candidate.law,
+        lawReference: conflict.candidate.lawReference,
+      });
+    } else if (request.resolution === 'kept_both') {
+      const questionId = ulid();
+      const now = new Date().toISOString();
+      const baseHash = hashContent(conflict.text, conflict.options);
+      const newQuestion: BankQuestionItem = {
+        PK: `QUESTION#${questionId}`,
+        SK: 'METADATA',
+        Type: 'BankQuestion',
+        questionId,
+        text: conflict.text,
+        options: conflict.options,
+        correctAnswer: conflict.candidate.correctAnswer,
+        explanation: conflict.candidate.explanation,
+        law: conflict.candidate.law,
+        lawReference: conflict.candidate.lawReference,
+        confidence: conflict.candidate.confidence,
+        // Goes into the bank as pending_review so an admin gives it a final
+        // look before it can be served in a quiz.
+        status: 'pending_review',
+        sourceFile: 'conflict-resolution',
+        jobId: conflict.jobId,
+        // Discriminate the hash so future identical-PDF imports still dedupe
+        // against the canonical original, not against this alternate version.
+        hash: `${baseHash}-${conflictId.slice(0, 8)}`,
+        createdAt: now,
+        updatedAt: now,
+        source: 'pdf_extraction',
+        usageCount: 0,
+      };
+      await batchSaveBankQuestions([newQuestion]);
+    }
+    // 'kept_existing' = no DB change beyond marking the conflict resolved.
+
+    await markConflictResolved(conflictId, request.resolution, resolvedBy);
+
+    return successResponse({
+      conflictId,
+      resolution: request.resolution,
+      message: 'Conflict resolved',
+    });
+  } catch (error) {
+    console.error('Error resolving conflict:', error);
+    return errorResponse('Failed to resolve conflict', 500);
+  }
+}
+
+function hashContent(text: string, options: string[]): string {
+  const content = `${text}|${options.join('|')}`.toLowerCase().trim();
+  return createHash('sha256').update(content).digest('hex').substring(0, 32);
+}

--- a/backend/src/lib/dynamodb.ts
+++ b/backend/src/lib/dynamodb.ts
@@ -20,6 +20,8 @@ import type {
   PerQuestionResult,
   LawStats,
   BookmarkItem,
+  QuestionConflictItem,
+  ConflictResolution,
 } from './types.js';
 
 const client = new DynamoDBClient({});
@@ -386,6 +388,16 @@ export async function getAllBankQuestions(limit = 100): Promise<BankQuestionItem
  * Check if a question with the same hash already exists
  */
 export async function questionExistsByHash(hash: string): Promise<boolean> {
+  const existing = await getBankQuestionByHash(hash);
+  return existing !== null;
+}
+
+/**
+ * Fetch the first bank question that matches a given content hash, or null.
+ * Used by the import flow to surface "looks like a duplicate but the answer
+ * has changed" conflicts for admin review.
+ */
+export async function getBankQuestionByHash(hash: string): Promise<BankQuestionItem | null> {
   const params = {
     TableName: TABLE_NAME,
     IndexName: 'Hash-index',
@@ -400,7 +412,8 @@ export async function questionExistsByHash(hash: string): Promise<boolean> {
   };
 
   const result = await docClient.send(new QueryCommand(params));
-  return (result.Items?.length || 0) > 0;
+  const items = (result.Items || []) as BankQuestionItem[];
+  return items[0] ?? null;
 }
 
 /**
@@ -729,5 +742,75 @@ export async function getUserBookmarks(userId: string): Promise<BookmarkItem[]> 
     })
   );
   return (result.Items || []) as BookmarkItem[];
+}
+
+// ============================================================================
+// Question conflicts (import-time answer-changed duplicates)
+// ============================================================================
+
+export async function saveQuestionConflict(item: QuestionConflictItem): Promise<void> {
+  await docClient.send(new PutCommand({ TableName: TABLE_NAME, Item: item }));
+}
+
+export async function getConflict(conflictId: string): Promise<QuestionConflictItem | null> {
+  const result = await docClient.send(
+    new GetCommand({
+      TableName: TABLE_NAME,
+      Key: { PK: `CONFLICT#${conflictId}`, SK: 'METADATA' },
+    })
+  );
+  return (result.Item as QuestionConflictItem | undefined) ?? null;
+}
+
+/**
+ * List conflicts by status (pending by default), newest first.
+ * Uses the Type-createdAt GSI with a FilterExpression on status — fine at
+ * the scale this admin queue runs at (tens of pending items, not thousands).
+ */
+export async function getConflictsByStatus(
+  status: 'pending' | 'resolved' = 'pending',
+  limit = 100
+): Promise<QuestionConflictItem[]> {
+  const result = await docClient.send(
+    new QueryCommand({
+      TableName: TABLE_NAME,
+      IndexName: 'Type-createdAt-index',
+      KeyConditionExpression: '#type = :type',
+      FilterExpression: '#status = :status',
+      ExpressionAttributeNames: {
+        '#type': 'Type',
+        '#status': 'status',
+      },
+      ExpressionAttributeValues: {
+        ':type': 'QuestionConflict',
+        ':status': status,
+      },
+      ScanIndexForward: false,
+      Limit: limit,
+    })
+  );
+  return (result.Items || []) as QuestionConflictItem[];
+}
+
+export async function markConflictResolved(
+  conflictId: string,
+  resolution: ConflictResolution,
+  resolvedBy: string
+): Promise<void> {
+  await docClient.send(
+    new UpdateCommand({
+      TableName: TABLE_NAME,
+      Key: { PK: `CONFLICT#${conflictId}`, SK: 'METADATA' },
+      UpdateExpression:
+        'SET #status = :status, resolution = :resolution, resolvedAt = :resolvedAt, resolvedBy = :resolvedBy',
+      ExpressionAttributeNames: { '#status': 'status' },
+      ExpressionAttributeValues: {
+        ':status': 'resolved',
+        ':resolution': resolution,
+        ':resolvedAt': new Date().toISOString(),
+        ':resolvedBy': resolvedBy,
+      },
+    })
+  );
 }
 

--- a/backend/src/lib/types.ts
+++ b/backend/src/lib/types.ts
@@ -111,6 +111,52 @@ export interface ExtractionJobItem {
   lawFilter?: Law;
   questionsPerAttempt?: number;
   shuffleOptions?: boolean;
+  // Conflict-detection counters (see QuestionConflictItem)
+  conflictCount?: number;
+}
+
+// ============================================================================
+// Import-time conflict between a PDF candidate and an existing bank question
+// ============================================================================
+
+export type ConflictResolution = 'kept_existing' | 'replaced' | 'kept_both';
+export type ConflictStatus = 'pending' | 'resolved';
+
+/**
+ * A candidate question extracted during PDF processing whose hash matches an
+ * existing approved/pending bank question but where one or more of the
+ * "outcome" fields (correctAnswer, explanation, lawReference, law) differ.
+ * Typically caused by IFAB law revisions changing the right answer to a
+ * question whose text/options the new PDF still poses the same way.
+ */
+export interface QuestionConflictItem {
+  PK: string; // CONFLICT#{conflictId}
+  SK: string; // METADATA
+  Type: 'QuestionConflict';
+  conflictId: string;
+  status: ConflictStatus;
+  existingQuestionId: string;
+  jobId: string; // job that produced the conflict
+  text: string;
+  options: string[];
+  existing: {
+    correctAnswer: number;
+    explanation: string;
+    law: Law;
+    lawReference: string;
+  };
+  candidate: {
+    correctAnswer: number;
+    explanation: string;
+    law: Law;
+    lawReference: string;
+    confidence: number;
+  };
+  diffFields: Array<'correctAnswer' | 'explanation' | 'law' | 'lawReference'>;
+  resolution?: ConflictResolution;
+  resolvedAt?: string;
+  resolvedBy?: string;
+  createdAt: string;
 }
 
 // API response types

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import AdminJobs from './pages/admin/Jobs';
 import AdminJobDetail from './pages/admin/JobDetail';
 import AdminReview from './pages/admin/Review';
 import AdminQuestionBank from './pages/admin/QuestionBank';
+import AdminConflicts from './pages/admin/Conflicts';
 import AdminCreateQuiz from './pages/admin/CreateQuiz';
 import AdminAddQuestion from './pages/admin/AddQuestion';
 import AdminManageQuizzes from './pages/admin/ManageQuizzes';
@@ -59,6 +60,7 @@ export default function App() {
         <Route path="jobs/:jobId/add" element={<AdminAddQuestion />} />
         <Route path="review" element={<AdminReview />} />
         <Route path="questions" element={<AdminQuestionBank />} />
+        <Route path="conflicts" element={<AdminConflicts />} />
       </Route>
     </Routes>
     </StatsProvider>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -25,6 +25,9 @@ import type {
   AdminAnalytics,
   PracticeQuizResponse,
   BookmarksResponse,
+  ConflictsResponse,
+  ConflictResolution,
+  ResolveConflictResponse,
 } from '../types';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
@@ -358,6 +361,31 @@ export async function getPracticeQuiz(
   return fetchAPI<PracticeQuizResponse>(
     `/me/practice-quiz${query ? `?${query}` : ''}`,
     undefined,
+    token
+  );
+}
+
+// Import conflicts
+export async function listConflicts(
+  token: string,
+  status: 'pending' | 'resolved' = 'pending'
+): Promise<ConflictsResponse> {
+  return fetchAPI<ConflictsResponse>(
+    `/admin/conflicts?status=${status}`,
+    undefined,
+    token
+  );
+}
+
+export async function resolveConflict(
+  conflictId: string,
+  resolution: ConflictResolution,
+  token: string,
+  resolvedBy?: string
+): Promise<ResolveConflictResponse> {
+  return fetchAPI<ResolveConflictResponse>(
+    `/admin/conflicts/${conflictId}/resolve`,
+    { method: 'POST', body: JSON.stringify({ resolution, resolvedBy }) },
     token
   );
 }

--- a/frontend/src/components/AdminLayout.tsx
+++ b/frontend/src/components/AdminLayout.tsx
@@ -8,6 +8,7 @@ const navItems = [
   { to: '/admin/jobs', label: 'Jobs' },
   { to: '/admin/review', label: 'Review Queue' },
   { to: '/admin/questions', label: 'Question Bank' },
+  { to: '/admin/conflicts', label: 'Conflicts' },
 ];
 
 export default function AdminLayout() {

--- a/frontend/src/pages/admin/Conflicts.tsx
+++ b/frontend/src/pages/admin/Conflicts.tsx
@@ -1,0 +1,291 @@
+import { useCallback, useEffect, useState } from 'react';
+import { listConflicts, resolveConflict } from '../../api/client';
+import { useAccessToken } from '../../hooks/useAccessToken';
+import type { ConflictResolution, ConflictStatus, QuestionConflict } from '../../types';
+
+const LETTERS = ['A', 'B', 'C', 'D'];
+
+export default function AdminConflicts() {
+  const { getToken } = useAccessToken();
+  const [conflicts, setConflicts] = useState<QuestionConflict[]>([]);
+  const [statusFilter, setStatusFilter] = useState<ConflictStatus>('pending');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [resolvingId, setResolvingId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const token = await getToken();
+      const res = await listConflicts(token, statusFilter);
+      setConflicts(res.conflicts);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load conflicts');
+    } finally {
+      setLoading(false);
+    }
+  }, [getToken, statusFilter]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleResolve = async (conflictId: string, resolution: ConflictResolution) => {
+    setResolvingId(conflictId);
+    try {
+      const token = await getToken();
+      await resolveConflict(conflictId, resolution, token);
+      setConflicts((prev) => prev.filter((c) => c.conflictId !== conflictId));
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to resolve conflict');
+    } finally {
+      setResolvingId(null);
+    }
+  };
+
+  return (
+    <div>
+      <div className="mb-6 flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Import Conflicts</h1>
+          <p className="text-gray-600">
+            Questions extracted from a new PDF that match an existing question by text and
+            options, but with a different answer or explanation. Often caused by IFAB law
+            updates changing the right answer to a familiar scenario.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {(['pending', 'resolved'] as ConflictStatus[]).map((s) => (
+            <button
+              key={s}
+              onClick={() => setStatusFilter(s)}
+              className={`px-3 py-1.5 text-sm rounded-md font-medium transition-colors ${
+                statusFilter === s
+                  ? 'bg-primary-600 text-white'
+                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+              }`}
+            >
+              {s === 'pending' ? 'Pending' : 'Resolved'}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center min-h-[200px]">
+          <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+        </div>
+      ) : error ? (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-6">
+          <p className="text-red-700">{error}</p>
+        </div>
+      ) : conflicts.length === 0 ? (
+        <div className="bg-white rounded-lg shadow p-12 text-center">
+          <p className="text-lg text-gray-600">
+            {statusFilter === 'pending' ? 'No pending conflicts' : 'No resolved conflicts yet'}
+          </p>
+          {statusFilter === 'pending' && (
+            <p className="text-sm text-gray-500 mt-2">
+              Conflicts will appear here automatically when a PDF import contains a question
+              whose answer differs from the existing version.
+            </p>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {conflicts.map((conflict) => (
+            <ConflictCard
+              key={conflict.conflictId}
+              conflict={conflict}
+              resolving={resolvingId === conflict.conflictId}
+              onResolve={(r) => handleResolve(conflict.conflictId, r)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ConflictCard({
+  conflict,
+  resolving,
+  onResolve,
+}: {
+  conflict: QuestionConflict;
+  resolving: boolean;
+  onResolve: (resolution: ConflictResolution) => void;
+}) {
+  const isResolved = conflict.status === 'resolved';
+  return (
+    <div className="bg-white rounded-lg shadow border border-amber-200">
+      <div className="px-6 py-4 border-b border-gray-200 flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-gray-900 line-clamp-2">{conflict.text}</p>
+          <p className="text-xs text-gray-500 mt-1">
+            From job {conflict.jobId} · {new Date(conflict.createdAt).toLocaleString()}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-1">
+          {conflict.diffFields.map((f) => (
+            <span
+              key={f}
+              className="px-2 py-0.5 text-xs font-medium rounded bg-amber-100 text-amber-800"
+            >
+              {f} differs
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className="px-6 py-4 grid gap-4 md:grid-cols-2">
+        <SidePanel
+          title="Existing question"
+          subtitle="Currently in the bank"
+          tone="gray"
+          options={conflict.options}
+          correctIndex={conflict.existing.correctAnswer}
+          law={conflict.existing.law}
+          lawReference={conflict.existing.lawReference}
+          explanation={conflict.existing.explanation}
+        />
+        <SidePanel
+          title="New candidate"
+          subtitle={`From the PDF import (${Math.round(conflict.candidate.confidence * 100)}% confidence)`}
+          tone="amber"
+          options={conflict.options}
+          correctIndex={conflict.candidate.correctAnswer}
+          law={conflict.candidate.law}
+          lawReference={conflict.candidate.lawReference}
+          explanation={conflict.candidate.explanation}
+          highlight={conflict.diffFields}
+          compareTo={conflict.existing}
+        />
+      </div>
+
+      {!isResolved && (
+        <div className="px-6 py-3 bg-gray-50 border-t border-gray-200 flex items-center justify-end gap-2 flex-wrap">
+          <button
+            onClick={() => onResolve('kept_existing')}
+            disabled={resolving}
+            className="btn-secondary text-sm disabled:opacity-50"
+          >
+            Keep existing
+          </button>
+          <button
+            onClick={() => onResolve('kept_both')}
+            disabled={resolving}
+            className="px-4 py-2 rounded-lg text-sm font-medium bg-blue-50 text-blue-700 hover:bg-blue-100 disabled:opacity-50"
+          >
+            Keep both
+          </button>
+          <button
+            onClick={() => onResolve('replaced')}
+            disabled={resolving}
+            className="btn-primary text-sm disabled:opacity-50"
+          >
+            {resolving ? 'Saving…' : 'Replace with new'}
+          </button>
+        </div>
+      )}
+
+      {isResolved && conflict.resolution && (
+        <div className="px-6 py-3 bg-gray-50 border-t border-gray-200 text-sm text-gray-600">
+          Resolved as <span className="font-medium">{labelForResolution(conflict.resolution)}</span>
+          {conflict.resolvedBy && ` by ${conflict.resolvedBy}`}
+          {conflict.resolvedAt && ` on ${new Date(conflict.resolvedAt).toLocaleString()}`}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SidePanel({
+  title,
+  subtitle,
+  tone,
+  options,
+  correctIndex,
+  law,
+  lawReference,
+  explanation,
+  highlight,
+  compareTo,
+}: {
+  title: string;
+  subtitle: string;
+  tone: 'gray' | 'amber';
+  options: string[];
+  correctIndex: number;
+  law: string;
+  lawReference: string;
+  explanation: string;
+  highlight?: QuestionConflict['diffFields'];
+  compareTo?: QuestionConflict['existing'];
+}) {
+  const headerTone = tone === 'amber' ? 'bg-amber-50 border-amber-200' : 'bg-gray-50 border-gray-200';
+  const diffMarks = new Set(highlight ?? []);
+
+  return (
+    <div className={`rounded-lg border ${headerTone} p-4`}>
+      <div className="mb-3">
+        <p className="text-sm font-semibold text-gray-900">{title}</p>
+        <p className="text-xs text-gray-500">{subtitle}</p>
+      </div>
+      <ul className="space-y-1.5 mb-3">
+        {options.map((opt, i) => {
+          const isCorrect = i === correctIndex;
+          const flipped =
+            compareTo && diffMarks.has('correctAnswer') && i === compareTo.correctAnswer && !isCorrect;
+          return (
+            <li
+              key={i}
+              className={`flex items-center gap-2 rounded px-2 py-1.5 text-sm ${
+                isCorrect
+                  ? 'bg-green-100 text-green-900 border border-green-200'
+                  : flipped
+                    ? 'bg-red-50 text-red-700 border border-red-200 line-through opacity-70'
+                    : 'bg-white text-gray-700 border border-gray-200'
+              }`}
+            >
+              <span className="text-xs font-mono w-4 flex-shrink-0">{LETTERS[i]}</span>
+              <span className="flex-1">{opt}</span>
+              {isCorrect && <span className="text-green-600 text-xs font-bold">✓</span>}
+            </li>
+          );
+        })}
+      </ul>
+      <div className="space-y-1 text-xs">
+        <p className={diffMarks.has('law') ? 'text-amber-700 font-medium' : 'text-gray-500'}>
+          Law: {law}
+        </p>
+        <p
+          className={diffMarks.has('lawReference') ? 'text-amber-700 font-medium' : 'text-gray-500'}
+        >
+          Ref: {lawReference || '—'}
+        </p>
+      </div>
+      {explanation && (
+        <p
+          className={`mt-2 text-xs ${
+            diffMarks.has('explanation') ? 'text-amber-700' : 'text-gray-600'
+          }`}
+        >
+          <span className="font-medium">Explanation:</span> {explanation}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function labelForResolution(r: ConflictResolution): string {
+  switch (r) {
+    case 'kept_existing':
+      return 'kept existing';
+    case 'replaced':
+      return 'replaced with new candidate';
+    case 'kept_both':
+      return 'kept both';
+  }
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -317,6 +317,48 @@ export interface BookmarksResponse {
   count: number;
 }
 
+// PDF import conflict types
+export type ConflictResolution = 'kept_existing' | 'replaced' | 'kept_both';
+export type ConflictStatus = 'pending' | 'resolved';
+
+export interface QuestionConflict {
+  conflictId: string;
+  status: ConflictStatus;
+  existingQuestionId: string;
+  jobId: string;
+  text: string;
+  options: string[];
+  existing: {
+    correctAnswer: number;
+    explanation: string;
+    law: Law;
+    lawReference: string;
+  };
+  candidate: {
+    correctAnswer: number;
+    explanation: string;
+    law: Law;
+    lawReference: string;
+    confidence: number;
+  };
+  diffFields: Array<'correctAnswer' | 'explanation' | 'law' | 'lawReference'>;
+  resolution?: ConflictResolution;
+  resolvedAt?: string;
+  resolvedBy?: string;
+  createdAt: string;
+}
+
+export interface ConflictsResponse {
+  conflicts: QuestionConflict[];
+  count: number;
+}
+
+export interface ResolveConflictResponse {
+  conflictId: string;
+  resolution: ConflictResolution;
+  message: string;
+}
+
 // Admin analytics types
 export interface AdminAnalyticsOverview {
   totalUsers: number;


### PR DESCRIPTION
## Why

When a PDF import extracts a question with the **same text + options** as one already in the bank, the old behaviour was a silent skip — but this is the wrong outcome when the new PDF actually carries a **different correct answer**, explanation, law, or law reference. This happens every IFAB law update: the scenario is the same, the right answer has changed. The fix surfaces those rows in a dedicated admin queue.

(Direct response to your ask: *"a duplicate question but with a different answer to the original… we should prompt the user that the outcome of it is different to what's currently in the question. This could occur during law changes or something else."*)

## How it works

**During PDF import** (`processPdf.ts`):
- `getBankQuestionByHash` replaces the existence-only check
- Compare `correctAnswer` / `explanation` / `law` / `lawReference`
- If any differ → write a `QuestionConflictItem` and increment `conflictCount` on the job
- If everything matches → silent duplicate skip, identical to before

**Admin queue** (`/admin/conflicts`):
- Side-by-side panels per conflict: existing on the left, candidate on the right
- Differing fields highlighted in amber. A flipped `correctAnswer` shows the existing answer red + struck-through and the candidate's answer green
- Status filter toggles between Pending and Resolved

**Three resolution actions:**

| | What it does |
|---|---|
| **Keep existing** | Drop the candidate; mark resolved. No DB change beyond the conflict row. |
| **Replace with new** | Overwrite the existing question's outcome fields with the candidate's. Text/options are unchanged (already matched). Reuses `updateBankQuestionContent` from #90. |
| **Keep both** | Insert the candidate as a new bank question (`pending_review` status) with a discriminated hash (`{originalHash}-{conflictId[:8]}`) so future identical-PDF imports still dedupe against the canonical original. |

## Files

**Backend**
- `lib/types.ts` — `QuestionConflictItem`, `ConflictResolution`, `ConflictStatus`. `ExtractionJobItem.conflictCount`.
- `lib/dynamodb.ts` — `getBankQuestionByHash`, `saveQuestionConflict`, `getConflict`, `getConflictsByStatus`, `markConflictResolved`.
- `handlers/processPdf.ts` — diff loop replacing the silent skip.
- `handlers/listConflicts.ts` — `GET /admin/conflicts?status=pending|resolved`.
- `handlers/resolveConflict.ts` — `POST /admin/conflicts/{id}/resolve`.

**Terraform**
- Two Lambdas, two API Gateway resources, two methods, two integrations, two CORS modules, two Lambda permissions, three new IDs in the deployment trigger.
- Wired through `outputs.tf` → `get-outputs` → two new `Update Lambda` steps in the workflow.

**Frontend**
- `pages/admin/Conflicts.tsx`, route registration, "Conflicts" nav entry, types + client.

## Test plan

- [ ] Import a PDF whose questions exactly match (text + options + answer) existing ones: `duplicateCount` increments, no conflict rows created.
- [ ] Import a PDF where the answer to an existing question has changed: a row appears at `/admin/conflicts` with the answer diff highlighted.
- [ ] **Keep existing** → row disappears from Pending, appears in Resolved with the resolution label.
- [ ] **Replace with new** → bank question's `correctAnswer` updates; verify in `/admin/questions`.
- [ ] **Keep both** → a second bank question appears in the pending-review queue with the new answer.
- [ ] CloudWatch logs for `processPdf` show `Conflict on question "…" diffs=…`.

## Follow-ups (separate)

- Show `conflictCount` badge on the Jobs page so an import surface flags conflicts at a glance.
- Unit tests for `listConflicts` / `resolveConflict` (mock dynamodb).

https://claude.ai/code/session_012ovSD71NbDWLfcCwfsdtE2

---
_Generated by [Claude Code](https://claude.ai/code/session_012ovSD71NbDWLfcCwfsdtE2)_