### PR TITLE
feat(daily-challenge): add daily challenge with streak tracking

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -215,6 +215,7 @@ jobs:
       lambda_get_bookmarks: ${{ steps.tf-output.outputs.lambda_get_bookmarks }}
       lambda_add_bookmark: ${{ steps.tf-output.outputs.lambda_add_bookmark }}
       lambda_remove_bookmark: ${{ steps.tf-output.outputs.lambda_remove_bookmark }}
+      lambda_get_daily_challenge: ${{ steps.tf-output.outputs.lambda_get_daily_challenge }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -265,6 +266,7 @@ jobs:
           echo "lambda_get_bookmarks=$(terraform output -json lambda_function_names | jq -r '.get_bookmarks')" >> $GITHUB_OUTPUT
           echo "lambda_add_bookmark=$(terraform output -json lambda_function_names | jq -r '.add_bookmark')" >> $GITHUB_OUTPUT
           echo "lambda_remove_bookmark=$(terraform output -json lambda_function_names | jq -r '.remove_bookmark')" >> $GITHUB_OUTPUT
+          echo "lambda_get_daily_challenge=$(terraform output -json lambda_function_names | jq -r '.get_daily_challenge')" >> $GITHUB_OUTPUT
 
   # Deploy Backend - uses pre-built artifacts
   deploy-backend:
@@ -464,6 +466,13 @@ jobs:
           aws lambda update-function-code \
             --function-name ${{ needs.get-outputs.outputs.lambda_remove_bookmark }} \
             --zip-file fileb://backend/dist/removeBookmark.zip
+
+      - name: Update Lambda - getDailyChallenge
+        if: needs.get-outputs.outputs.lambda_get_daily_challenge != '' && needs.get-outputs.outputs.lambda_get_daily_challenge != 'null'
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ needs.get-outputs.outputs.lambda_get_daily_challenge }} \
+            --zip-file fileb://backend/dist/getDailyChallenge.zip
 
   # Build and Deploy Frontend
   deploy-frontend:

--- a/.infra/modules/backend/main.tf
+++ b/.infra/modules/backend/main.tf
@@ -32,6 +32,7 @@ locals {
     "addBookmark",
     "removeBookmark",
     "getBookmarks",
+    "getDailyChallenge",
   ]
 }
 
@@ -451,6 +452,8 @@ resource "aws_api_gateway_deployment" "this" {
     aws_api_gateway_integration.get_bookmarks,
     aws_api_gateway_integration.add_bookmark,
     aws_api_gateway_integration.remove_bookmark,
+    aws_api_gateway_integration.get_daily_challenge,
+    aws_api_gateway_integration.post_daily_challenge,
   ]
 
   lifecycle {
@@ -489,6 +492,7 @@ resource "aws_api_gateway_deployment" "this" {
       aws_api_gateway_resource.admin_conflicts.id,
       aws_api_gateway_resource.admin_conflict_id.id,
       aws_api_gateway_resource.admin_conflict_resolve.id,
+      aws_api_gateway_resource.me_daily_challenge.id,
       [for r in aws_api_gateway_gateway_response.cors : r.id],
     ]))
   }
@@ -2248,6 +2252,86 @@ resource "aws_lambda_permission" "remove_bookmark" {
   statement_id  = "AllowAPIGatewayInvoke"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.remove_bookmark.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
+}
+
+# ============================================================================
+# Daily Challenge (GET & POST /me/daily-challenge)
+# ============================================================================
+
+resource "aws_lambda_function" "get_daily_challenge" {
+  filename         = "${path.module}/../../../backend/dist/getDailyChallenge.zip"
+  function_name    = "${var.project_name}-${var.environment}-getDailyChallenge"
+  role             = aws_iam_role.lambda.arn
+  handler          = "index.handler"
+  runtime          = "nodejs24.x"
+  timeout          = 15
+  memory_size      = 256
+  source_code_hash = fileexists("${path.module}/../../../backend/dist/getDailyChallenge.zip") ? filebase64sha256("${path.module}/../../../backend/dist/getDailyChallenge.zip") : null
+
+  environment {
+    variables = {
+      TABLE_NAME   = var.dynamodb_table_name
+      AUTH0_DOMAIN = var.auth0_domain
+      NODE_ENV     = var.environment
+    }
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-getDailyChallenge"
+  }
+}
+
+resource "aws_api_gateway_resource" "me_daily_challenge" {
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  parent_id   = aws_api_gateway_resource.me.id
+  path_part   = "daily-challenge"
+}
+
+resource "aws_api_gateway_method" "get_daily_challenge" {
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  resource_id   = aws_api_gateway_resource.me_daily_challenge.id
+  http_method   = "GET"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "get_daily_challenge" {
+  rest_api_id             = aws_api_gateway_rest_api.this.id
+  resource_id             = aws_api_gateway_resource.me_daily_challenge.id
+  http_method             = aws_api_gateway_method.get_daily_challenge.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.get_daily_challenge.invoke_arn
+}
+
+resource "aws_api_gateway_method" "post_daily_challenge" {
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  resource_id   = aws_api_gateway_resource.me_daily_challenge.id
+  http_method   = "POST"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "post_daily_challenge" {
+  rest_api_id             = aws_api_gateway_rest_api.this.id
+  resource_id             = aws_api_gateway_resource.me_daily_challenge.id
+  http_method             = aws_api_gateway_method.post_daily_challenge.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.get_daily_challenge.invoke_arn
+}
+
+module "cors_me_daily_challenge" {
+  source = "../cors"
+
+  api_id          = aws_api_gateway_rest_api.this.id
+  api_resource_id = aws_api_gateway_resource.me_daily_challenge.id
+}
+
+resource "aws_lambda_permission" "get_daily_challenge" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.get_daily_challenge.function_name
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
 }

--- a/.infra/modules/backend/outputs.tf
+++ b/.infra/modules/backend/outputs.tf
@@ -43,6 +43,7 @@ output "lambda_function_names" {
     get_bookmarks          = aws_lambda_function.get_bookmarks.function_name
     add_bookmark           = aws_lambda_function.add_bookmark.function_name
     remove_bookmark        = aws_lambda_function.remove_bookmark.function_name
+    get_daily_challenge    = aws_lambda_function.get_daily_challenge.function_name
   }
 }
 
@@ -76,6 +77,7 @@ output "lambda_function_arns" {
     get_bookmarks          = aws_lambda_function.get_bookmarks.arn
     add_bookmark           = aws_lambda_function.add_bookmark.arn
     remove_bookmark        = aws_lambda_function.remove_bookmark.arn
+    get_daily_challenge    = aws_lambda_function.get_daily_challenge.arn
   }
 }
 

--- a/backend/build.js
+++ b/backend/build.js
@@ -49,6 +49,8 @@ const handlers = [
   // Import conflict review
   'listConflicts',
   'resolveConflict',
+  // Daily challenge
+  'getDailyChallenge',
 ];
 
 async function buildHandler(handlerName) {

--- a/backend/src/handlers/getDailyChallenge.ts
+++ b/backend/src/handlers/getDailyChallenge.ts
@@ -1,0 +1,207 @@
+import type {
+  APIGatewayProxyEvent,
+  APIGatewayProxyResult,
+  BankQuestionItem,
+} from '../lib/types.js';
+import { getUserStats, updateUserStats } from '../lib/dynamodb.js';
+import { successResponse, errorResponse } from '../lib/response.js';
+import { verifyToken } from '../lib/verifyToken.js';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+} from '@aws-sdk/lib-dynamodb';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import type { PerQuestionResult } from '../lib/types.js';
+
+const client = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(client);
+const TABLE_NAME = process.env.TABLE_NAME || 'lotg-exams-prod-quizzes';
+const DAILY_QUESTION_COUNT = 5;
+
+/** Simple seeded PRNG (mulberry32) for deterministic question selection */
+function seededRandom(seed: number): () => number {
+  return () => {
+    seed |= 0;
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function hashString(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
+  }
+  return hash;
+}
+
+function getToday(): string {
+  return new Date().toISOString().substring(0, 10);
+}
+
+async function getDailyCompletion(userId: string, date: string) {
+  const result = await docClient.send(
+    new GetCommand({
+      TableName: TABLE_NAME,
+      Key: { PK: `USER#${userId}`, SK: `DAILY#${date}` },
+    })
+  );
+  return result.Item || null;
+}
+
+async function getAllApprovedQuestions(): Promise<BankQuestionItem[]> {
+  const items: BankQuestionItem[] = [];
+  let lastKey: Record<string, unknown> | undefined;
+  do {
+    const result = await docClient.send(
+      new QueryCommand({
+        TableName: TABLE_NAME,
+        IndexName: 'Status-CreatedAt-index',
+        KeyConditionExpression: '#status = :status',
+        ExpressionAttributeNames: { '#status': 'status' },
+        ExpressionAttributeValues: { ':status': 'approved' },
+        ExclusiveStartKey: lastKey,
+      })
+    );
+    items.push(...((result.Items || []) as BankQuestionItem[]));
+    lastKey = result.LastEvaluatedKey;
+  } while (lastKey);
+  return items;
+}
+
+function selectDailyQuestions(
+  questions: BankQuestionItem[],
+  date: string,
+  userId: string
+): BankQuestionItem[] {
+  if (questions.length <= DAILY_QUESTION_COUNT) return questions;
+  const seed = hashString(`${date}:${userId}`);
+  const rng = seededRandom(seed);
+  // Fisher-Yates with seeded RNG
+  const pool = [...questions];
+  for (let i = pool.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [pool[i], pool[j]] = [pool[j], pool[i]];
+  }
+  return pool.slice(0, DAILY_QUESTION_COUNT);
+}
+
+export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  const userId = await verifyToken(event.headers?.Authorization || event.headers?.authorization);
+  if (!userId) return errorResponse('Authentication required', 401);
+
+  const today = getToday();
+
+  if (event.httpMethod === 'GET') {
+    try {
+      const [completion, stats, allQuestions] = await Promise.all([
+        getDailyCompletion(userId, today),
+        getUserStats(userId),
+        getAllApprovedQuestions(),
+      ]);
+
+      const selected = selectDailyQuestions(allQuestions, today, userId);
+      const questions = selected.map((q) => ({
+        questionId: q.questionId,
+        text: q.text,
+        options: q.options,
+        correctAnswer: completion ? q.correctAnswer : undefined,
+        explanation: completion ? q.explanation : undefined,
+        lawReference: completion ? q.lawReference : undefined,
+      }));
+
+      return successResponse({
+        date: today,
+        questions,
+        completed: !!completion,
+        score: completion?.score ?? null,
+        streak: stats?.currentStreak ?? 0,
+      });
+    } catch (error) {
+      console.error('Error fetching daily challenge:', error);
+      return errorResponse('Failed to fetch daily challenge', 500);
+    }
+  }
+
+  if (event.httpMethod === 'POST') {
+    try {
+      const existing = await getDailyCompletion(userId, today);
+      if (existing) return errorResponse("Already completed today's challenge", 409);
+
+      const body = JSON.parse(event.body || '{}');
+      const answers: Array<{ questionId: string; selectedOption: number }> = body.answers;
+      if (!answers?.length) return errorResponse('answers array required', 400);
+
+      const allQuestions = await getAllApprovedQuestions();
+      const selected = selectDailyQuestions(allQuestions, today, userId);
+      const questionMap = new Map(selected.map((q) => [q.questionId, q]));
+
+      let correct = 0;
+      const questionResults: PerQuestionResult[] = [];
+      const results = answers
+        .map((a) => {
+          const q = questionMap.get(a.questionId);
+          if (!q) return null;
+          const isCorrect = a.selectedOption === q.correctAnswer;
+          if (isCorrect) correct++;
+          questionResults.push({
+            questionId: q.questionId,
+            selectedOption: a.selectedOption,
+            isCorrect,
+            law: q.law,
+          });
+          return {
+            questionId: q.questionId,
+            text: q.text,
+            options: q.options,
+            selectedOption: a.selectedOption,
+            correctOption: q.correctAnswer,
+            isCorrect,
+            explanation: q.explanation,
+            lawReference: q.lawReference,
+          };
+        })
+        .filter(Boolean);
+
+      const percentage = Math.round((correct / DAILY_QUESTION_COUNT) * 100);
+
+      // Save completion
+      await docClient.send(
+        new PutCommand({
+          TableName: TABLE_NAME,
+          Item: {
+            PK: `USER#${userId}`,
+            SK: `DAILY#${today}`,
+            Type: 'DailyCompletion',
+            userId,
+            date: today,
+            score: correct,
+            total: DAILY_QUESTION_COUNT,
+            percentage,
+            createdAt: new Date().toISOString(),
+          },
+        })
+      );
+
+      // Update user stats (drives streak)
+      await updateUserStats(userId, percentage, questionResults);
+
+      const stats = await getUserStats(userId);
+
+      return successResponse({
+        results,
+        score: { correct, total: DAILY_QUESTION_COUNT, percentage },
+        streak: stats?.currentStreak ?? 1,
+      });
+    } catch (error) {
+      console.error('Error submitting daily challenge:', error);
+      return errorResponse('Failed to submit daily challenge', 500);
+    }
+  }
+
+  return errorResponse('Method not allowed', 405);
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,47 +22,49 @@ import HistoryPage from './pages/HistoryPage';
 import PracticeTake from './pages/PracticeTake';
 import MockExam from './pages/MockExam';
 import BookmarksPage from './pages/BookmarksPage';
+import DailyChallengePage from './pages/DailyChallenge';
 import { StatsProvider } from './contexts/StatsContext';
 
 export default function App() {
   return (
     <StatsProvider>
-    <Routes>
-      {/* Public routes with Navbar */}
-      <Route element={<Layout />}>
-        <Route path="/" element={<QuizList />} />
-        <Route path="/quiz/:quizId" element={<QuizTake />} />
-        <Route path="/quiz/:quizId/results" element={<QuizResults />} />
-        <Route path="/profile" element={<ProfilePage />} />
-        <Route path="/history" element={<HistoryPage />} />
-        <Route path="/practice" element={<PracticeTake />} />
-        <Route path="/mock-exam" element={<MockExam />} />
-        <Route path="/bookmarks" element={<BookmarksPage />} />
-      </Route>
+      <Routes>
+        {/* Public routes with Navbar */}
+        <Route element={<Layout />}>
+          <Route path="/" element={<QuizList />} />
+          <Route path="/quiz/:quizId" element={<QuizTake />} />
+          <Route path="/quiz/:quizId/results" element={<QuizResults />} />
+          <Route path="/profile" element={<ProfilePage />} />
+          <Route path="/history" element={<HistoryPage />} />
+          <Route path="/practice" element={<PracticeTake />} />
+          <Route path="/mock-exam" element={<MockExam />} />
+          <Route path="/bookmarks" element={<BookmarksPage />} />
+          <Route path="/daily-challenge" element={<DailyChallengePage />} />
+        </Route>
 
-      {/* Protected admin routes */}
-      <Route
-        path="/admin"
-        element={
-          <ProtectedRoute requiredRole="admin">
-            <AdminLayout />
-          </ProtectedRoute>
-        }
-      >
-        <Route index element={<AdminDashboard />} />
-        <Route path="quizzes" element={<AdminManageQuizzes />} />
-        <Route path="quizzes/:jobId" element={<AdminQuizQuestions />} />
-        <Route path="quizzes/:jobId/edit" element={<AdminEditQuiz />} />
-        <Route path="upload" element={<AdminUpload />} />
-        <Route path="create" element={<AdminCreateQuiz />} />
-        <Route path="jobs" element={<AdminJobs />} />
-        <Route path="jobs/:jobId" element={<AdminJobDetail />} />
-        <Route path="jobs/:jobId/add" element={<AdminAddQuestion />} />
-        <Route path="review" element={<AdminReview />} />
-        <Route path="questions" element={<AdminQuestionBank />} />
-        <Route path="conflicts" element={<AdminConflicts />} />
-      </Route>
-    </Routes>
+        {/* Protected admin routes */}
+        <Route
+          path="/admin"
+          element={
+            <ProtectedRoute requiredRole="admin">
+              <AdminLayout />
+            </ProtectedRoute>
+          }
+        >
+          <Route index element={<AdminDashboard />} />
+          <Route path="quizzes" element={<AdminManageQuizzes />} />
+          <Route path="quizzes/:jobId" element={<AdminQuizQuestions />} />
+          <Route path="quizzes/:jobId/edit" element={<AdminEditQuiz />} />
+          <Route path="upload" element={<AdminUpload />} />
+          <Route path="create" element={<AdminCreateQuiz />} />
+          <Route path="jobs" element={<AdminJobs />} />
+          <Route path="jobs/:jobId" element={<AdminJobDetail />} />
+          <Route path="jobs/:jobId/add" element={<AdminAddQuestion />} />
+          <Route path="review" element={<AdminReview />} />
+          <Route path="questions" element={<AdminQuestionBank />} />
+          <Route path="conflicts" element={<AdminConflicts />} />
+        </Route>
+      </Routes>
     </StatsProvider>
   );
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -370,11 +370,7 @@ export async function listConflicts(
   token: string,
   status: 'pending' | 'resolved' = 'pending'
 ): Promise<ConflictsResponse> {
-  return fetchAPI<ConflictsResponse>(
-    `/admin/conflicts?status=${status}`,
-    undefined,
-    token
-  );
+  return fetchAPI<ConflictsResponse>(`/admin/conflicts?status=${status}`, undefined, token);
 }
 
 export async function resolveConflict(
@@ -386,6 +382,52 @@ export async function resolveConflict(
   return fetchAPI<ResolveConflictResponse>(
     `/admin/conflicts/${conflictId}/resolve`,
     { method: 'POST', body: JSON.stringify({ resolution, resolvedBy }) },
+    token
+  );
+}
+
+// Daily Challenge
+export interface DailyChallengeResponse {
+  date: string;
+  questions: Array<{
+    questionId: string;
+    text: string;
+    options: string[];
+    correctAnswer?: number;
+    explanation?: string;
+    lawReference?: string;
+  }>;
+  completed: boolean;
+  score: number | null;
+  streak: number;
+}
+
+export interface DailyChallengeSubmitResponse {
+  results: Array<{
+    questionId: string;
+    text: string;
+    options: string[];
+    selectedOption: number;
+    correctOption: number;
+    isCorrect: boolean;
+    explanation: string;
+    lawReference: string;
+  }>;
+  score: { correct: number; total: number; percentage: number };
+  streak: number;
+}
+
+export async function getDailyChallenge(token: string): Promise<DailyChallengeResponse> {
+  return fetchAPI<DailyChallengeResponse>('/me/daily-challenge', undefined, token);
+}
+
+export async function submitDailyChallenge(
+  answers: Array<{ questionId: string; selectedOption: number }>,
+  token: string
+): Promise<DailyChallengeSubmitResponse> {
+  return fetchAPI<DailyChallengeSubmitResponse>(
+    '/me/daily-challenge',
+    { method: 'POST', body: JSON.stringify({ answers }) },
     token
   );
 }

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -36,6 +36,12 @@ export default function Navbar() {
                     </span>
                   )}
                 </Link>
+                <Link
+                  to="/daily-challenge"
+                  className="px-3 py-2 text-sm font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-md transition-colors"
+                >
+                  Daily
+                </Link>
                 {isAdmin && (
                   <Link
                     to="/admin"

--- a/frontend/src/pages/DailyChallenge.tsx
+++ b/frontend/src/pages/DailyChallenge.tsx
@@ -1,0 +1,227 @@
+import { useEffect, useState } from 'react';
+import { useAuth0 } from '@auth0/auth0-react';
+import { useAccessToken } from '../hooks/useAccessToken';
+import { getDailyChallenge, submitDailyChallenge } from '../api/client';
+import type { DailyChallengeResponse, DailyChallengeSubmitResponse } from '../api/client';
+
+const OPTION_LABELS = 'ABCD';
+
+type Phase = 'loading' | 'quiz' | 'results' | 'already-completed' | 'error';
+
+export default function DailyChallengePage() {
+  const { isAuthenticated, loginWithRedirect } = useAuth0();
+  const { getToken } = useAccessToken();
+
+  const [phase, setPhase] = useState<Phase>('loading');
+  const [challenge, setChallenge] = useState<DailyChallengeResponse | null>(null);
+  const [answers, setAnswers] = useState<Record<string, number>>({});
+  const [submitResult, setSubmitResult] = useState<DailyChallengeSubmitResponse | null>(null);
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const token = await getToken();
+        const data = await getDailyChallenge(token);
+        if (cancelled) return;
+        setChallenge(data);
+        setPhase(data.completed ? 'already-completed' : 'quiz');
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : 'Failed to load');
+        setPhase('error');
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, getToken]);
+
+  async function handleSubmit() {
+    if (!challenge) return;
+    const unanswered = challenge.questions.filter((q) => answers[q.questionId] === undefined);
+    if (unanswered.length > 0) return;
+
+    setSubmitting(true);
+    try {
+      const token = await getToken();
+      const result = await submitDailyChallenge(
+        challenge.questions.map((q) => ({
+          questionId: q.questionId,
+          selectedOption: answers[q.questionId],
+        })),
+        token
+      );
+      setSubmitResult(result);
+      setPhase('results');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Submit failed');
+      setPhase('error');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div className="max-w-lg mx-auto mt-16 text-center">
+        <h1 className="text-2xl font-bold mb-4">Daily Challenge</h1>
+        <p className="text-gray-600 mb-6">
+          Log in to access your daily challenge and build your streak.
+        </p>
+        <button
+          onClick={() => loginWithRedirect()}
+          className="bg-green-600 text-white px-6 py-2 rounded-lg hover:bg-green-700"
+        >
+          Log In
+        </button>
+      </div>
+    );
+  }
+
+  if (phase === 'loading') {
+    return (
+      <div className="max-w-lg mx-auto mt-16 text-center">
+        <div className="animate-pulse text-gray-500">Loading today's challenge...</div>
+      </div>
+    );
+  }
+
+  if (phase === 'error') {
+    return (
+      <div className="max-w-lg mx-auto mt-16 text-center">
+        <p className="text-red-600 mb-4">{error}</p>
+        <button onClick={() => window.location.reload()} className="text-green-600 underline">
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (phase === 'already-completed' && challenge) {
+    return (
+      <div className="max-w-lg mx-auto mt-12 px-4">
+        <div className="text-center mb-8">
+          <div className="text-4xl mb-2">✅</div>
+          <h1 className="text-2xl font-bold mb-2">Challenge Complete!</h1>
+          <p className="text-gray-600">
+            You scored{' '}
+            <span className="font-semibold">
+              {challenge.score}/{challenge.questions.length}
+            </span>{' '}
+            today.
+          </p>
+          <div className="mt-4 inline-flex items-center gap-2 bg-orange-50 text-orange-700 px-4 py-2 rounded-full">
+            <span className="text-xl">🔥</span>
+            <span className="font-semibold">{challenge.streak} day streak</span>
+          </div>
+        </div>
+        <p className="text-center text-gray-500 text-sm">Come back tomorrow for a new challenge!</p>
+      </div>
+    );
+  }
+
+  if (phase === 'results' && submitResult) {
+    const { score, streak, results } = submitResult;
+    return (
+      <div className="max-w-2xl mx-auto mt-8 px-4">
+        <div className="text-center mb-8">
+          <h1 className="text-2xl font-bold mb-2">Daily Challenge Results</h1>
+          <p className="text-4xl font-bold text-green-600 mb-1">
+            {score.correct}/{score.total}
+          </p>
+          <p className="text-gray-500">{score.percentage}%</p>
+          <div className="mt-3 inline-flex items-center gap-2 bg-orange-50 text-orange-700 px-4 py-2 rounded-full">
+            <span className="text-xl">🔥</span>
+            <span className="font-semibold">{streak} day streak</span>
+          </div>
+        </div>
+        <div className="space-y-4">
+          {results.map((r) => (
+            <div
+              key={r.questionId}
+              className={`p-4 rounded-lg border ${r.isCorrect ? 'border-green-200 bg-green-50' : 'border-red-200 bg-red-50'}`}
+            >
+              <p className="font-medium mb-2">{r.text}</p>
+              <div className="space-y-1 text-sm mb-2">
+                {r.options.map((opt, i) => (
+                  <div
+                    key={i}
+                    className={`px-2 py-1 rounded ${i === r.correctOption ? 'bg-green-200 font-medium' : i === r.selectedOption && !r.isCorrect ? 'bg-red-200' : ''}`}
+                  >
+                    {OPTION_LABELS[i]}. {opt}
+                  </div>
+                ))}
+              </div>
+              <p className="text-xs text-gray-600">{r.explanation}</p>
+              <p className="text-xs text-gray-400 mt-1">{r.lawReference}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // Quiz phase
+  if (!challenge) return null;
+  const allAnswered = challenge.questions.every((q) => answers[q.questionId] !== undefined);
+
+  return (
+    <div className="max-w-2xl mx-auto mt-8 px-4">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold">Daily Challenge</h1>
+        <div className="flex items-center gap-2 text-orange-600">
+          <span>🔥</span>
+          <span className="font-semibold">{challenge.streak} day streak</span>
+        </div>
+      </div>
+      <p className="text-gray-500 text-sm mb-6">
+        {challenge.date} • {challenge.questions.length} questions
+      </p>
+
+      <div className="space-y-6">
+        {challenge.questions.map((q, qi) => (
+          <div key={q.questionId} className="p-4 border rounded-lg">
+            <p className="font-medium mb-3">
+              {qi + 1}. {q.text}
+            </p>
+            <div className="space-y-2">
+              {q.options.map((opt, i) => (
+                <button
+                  key={i}
+                  onClick={() => setAnswers((prev) => ({ ...prev, [q.questionId]: i }))}
+                  className={`w-full text-left px-3 py-2 rounded border transition ${
+                    answers[q.questionId] === i
+                      ? 'border-green-600 bg-green-50 text-green-800'
+                      : 'border-gray-200 hover:border-gray-400'
+                  }`}
+                >
+                  {OPTION_LABELS[i]}. {opt}
+                </button>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-8 mb-12 text-center">
+        <button
+          onClick={handleSubmit}
+          disabled={!allAnswered || submitting}
+          className="bg-green-600 text-white px-8 py-3 rounded-lg font-semibold hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {submitting ? 'Submitting...' : 'Submit Challenge'}
+        </button>
+        {!allAnswered && (
+          <p className="text-sm text-gray-400 mt-2">Answer all questions to submit</p>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a Daily Challenge feature — 5 questions per day, deterministic per-user selection, with streak integration.

### Changes

**Backend:**
- `getDailyChallenge` handler: GET returns today's questions + completion status, POST submits answers
- Uses seeded PRNG (mulberry32) so same user gets same 5 questions all day
- Stores completion as `PK=USER#{userId} SK=DAILY#{date}` in DynamoDB
- Updates existing UserStats streak tracking on completion

**Frontend:**
- `/daily-challenge` page with quiz UI, results review, and streak display
- "Daily" nav link in Navbar
- API client functions for GET/POST

**Infrastructure:**
- Lambda function + API Gateway GET/POST methods on `/me/daily-challenge`
- CORS module, permissions, deployment triggers
- Deploy workflow wiring (output, jq, update step)

### How to test

1. Log in → click "Daily" in nav
2. Answer 5 questions → submit
3. See results with streak counter
4. Revisit page same day → shows completion state
5. Next day → new questions

### Checklist
- [x] Backend builds, 65 tests pass
- [x] Frontend builds
- [x] Terraform validates