### PR TITLE
feat(admin): add streak leaderboard to dashboard

### DIFF
--- a/backend/src/handlers/getAdminAnalytics.ts
+++ b/backend/src/handlers/getAdminAnalytics.ts
@@ -11,6 +11,12 @@ export interface AdminAnalyticsResponse {
     totalQuestionsAvailable: number;
   };
   byLaw: Partial<Record<Law, { attempts: number; avgScore: number }>>;
+  streakLeaderboard: Array<{
+    userId: string;
+    currentStreak: number;
+    longestStreak: number;
+    lastStudyDate?: string;
+  }>;
 }
 
 export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
@@ -18,7 +24,10 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
     const [jobs, userStats] = await Promise.all([getAllExtractionJobs(), getAllUserStats()]);
 
     const publishedJobs = jobs.filter((j) => j.published === true);
-    const totalQuestionsAvailable = publishedJobs.reduce((sum, j) => sum + (j.approvedCount || 0), 0);
+    const totalQuestionsAvailable = publishedJobs.reduce(
+      (sum, j) => sum + (j.approvedCount || 0),
+      0
+    );
 
     const usersWithAttempts = userStats.filter((u) => u.totalAttempts > 0);
     const totalAttempts = userStats.reduce((sum, u) => sum + u.totalAttempts, 0);
@@ -38,7 +47,10 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
     }
 
     const byLawSummary: Partial<Record<Law, { attempts: number; avgScore: number }>> = {};
-    for (const [law, data] of Object.entries(byLaw) as [Law, { totalAttempts: number; totalCorrect: number }][]) {
+    for (const [law, data] of Object.entries(byLaw) as [
+      Law,
+      { totalAttempts: number; totalCorrect: number },
+    ][]) {
       byLawSummary[law] = {
         attempts: data.totalAttempts,
         avgScore: data.totalAttempts > 0 ? (data.totalCorrect / data.totalAttempts) * 100 : 0,
@@ -54,6 +66,16 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
         totalQuestionsAvailable,
       },
       byLaw: byLawSummary,
+      streakLeaderboard: userStats
+        .filter((u) => u.currentStreak > 0 || u.longestStreak > 0)
+        .sort((a, b) => b.currentStreak - a.currentStreak || b.longestStreak - a.longestStreak)
+        .slice(0, 10)
+        .map((u) => ({
+          userId: u.userId,
+          currentStreak: u.currentStreak,
+          longestStreak: u.longestStreak,
+          lastStudyDate: u.lastStudyDate,
+        })),
     };
 
     return successResponse(response);

--- a/frontend/src/pages/admin/Dashboard.tsx
+++ b/frontend/src/pages/admin/Dashboard.tsx
@@ -246,11 +246,14 @@ export default function AdminDashboard() {
 
             {Object.keys(analytics.byLaw).length > 0 && (
               <div className="bg-white rounded-lg shadow p-6">
-                <h3 className="text-base font-semibold text-gray-900 mb-4">
-                  Performance by Law
-                </h3>
+                <h3 className="text-base font-semibold text-gray-900 mb-4">Performance by Law</h3>
                 <div className="space-y-3">
-                  {(Object.entries(analytics.byLaw) as [string, { attempts: number; avgScore: number }][])
+                  {(
+                    Object.entries(analytics.byLaw) as [
+                      string,
+                      { attempts: number; avgScore: number },
+                    ][]
+                  )
                     .sort(([a], [b]) => {
                       const num = (s: string) => parseInt(s.replace('Law ', ''), 10);
                       return num(a) - num(b);
@@ -282,6 +285,48 @@ export default function AdminDashboard() {
                         </div>
                       );
                     })}
+                </div>
+              </div>
+            )}
+
+            {analytics.streakLeaderboard && analytics.streakLeaderboard.length > 0 && (
+              <div className="bg-white rounded-lg shadow p-6">
+                <h3 className="text-base font-semibold text-gray-900 mb-4">
+                  🔥 Streak Leaderboard
+                </h3>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="text-left text-gray-500 border-b">
+                        <th className="pb-2 font-medium">#</th>
+                        <th className="pb-2 font-medium">User</th>
+                        <th className="pb-2 font-medium text-right">Current Streak</th>
+                        <th className="pb-2 font-medium text-right">Longest Streak</th>
+                        <th className="pb-2 font-medium text-right">Last Active</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-100">
+                      {analytics.streakLeaderboard.map((entry, idx) => (
+                        <tr key={entry.userId}>
+                          <td className="py-2 text-gray-400">{idx + 1}</td>
+                          <td className="py-2 font-medium text-gray-900 truncate max-w-[200px]">
+                            {entry.userId.includes('|')
+                              ? entry.userId.split('|')[1]?.slice(0, 12) + '…'
+                              : entry.userId.slice(0, 16)}
+                          </td>
+                          <td className="py-2 text-right">
+                            <span className="inline-flex items-center gap-1 text-orange-600 font-semibold">
+                              🔥 {entry.currentStreak}
+                            </span>
+                          </td>
+                          <td className="py-2 text-right text-gray-600">{entry.longestStreak}</td>
+                          <td className="py-2 text-right text-gray-400">
+                            {entry.lastStudyDate || '—'}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
                 </div>
               </div>
             )}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -371,4 +371,10 @@ export interface AdminAnalyticsOverview {
 export interface AdminAnalytics {
   overview: AdminAnalyticsOverview;
   byLaw: Partial<Record<Law, { attempts: number; avgScore: number }>>;
+  streakLeaderboard: Array<{
+    userId: string;
+    currentStreak: number;
+    longestStreak: number;
+    lastStudyDate?: string;
+  }>;
 }


### PR DESCRIPTION
Adds a streak leaderboard table to the admin analytics dashboard showing the top 10 users by current daily streak.

### Changes
- **Backend**: `getAdminAnalytics` now returns `streakLeaderboard` (top 10 by current streak, no new Lambda/endpoint needed)
- **Frontend**: Table in Learner Analytics section showing rank, user ID, current streak 🔥, longest streak, and last active date

No infra changes required — extends existing endpoint.